### PR TITLE
[Internal Search] Add query params hook filter

### DIFF
--- a/doofinder-for-woocommerce/includes/class-internal-search.php
+++ b/doofinder-for-woocommerce/includes/class-internal-search.php
@@ -389,12 +389,16 @@ class Internal_Search {
 		// and Internal Search will display empty list of results.
 		try {
 
-			$queryParams = [
-				"hashid" => $this->hashid,
-				"query" => $query,
-				"page" => $page,
-				'rpp' => $per_page
-			];
+			$queryParams = apply_filters(
+				'woocommerce_doofinder_internal_search_params', 
+				[
+					"hashid" => $this->hashid,
+					"query" => $query,
+					"page" => $page,
+					'rpp' => $per_page
+				],
+				$this
+			);
 
 			$log->log( 'Internal Search - Search: ' );
 			$log->log( $queryParams );


### PR DESCRIPTION
With this change developers can use WooCommerce filters with Doofinder internal search. New filter `woocommerce_doofinder_internal_search_params` is added.