### PR TITLE
Fix wordpress api connection

### DIFF
--- a/doofinder-for-woocommerce/assets/js/df-add-to-cart.js
+++ b/doofinder-for-woocommerce/assets/js/df-add-to-cart.js
@@ -11,9 +11,13 @@
     item_id = parseInt(item_id);
 
     $.ajax({
-      type: "get",
-      url: df_cart.item_info_endpoint + item_id,
+      type: "post",
+      url: df_cart.ajax_url,
       dataType: "json",
+      data: {
+        action: "doofinder_get_product_info",
+        id: item_id,
+      },
       success: function (response) {
         if (response.add_to_cart) {
           wc_add_to_cart(response.product, response.variation, amount);

--- a/doofinder-for-woocommerce/assets/js/wizard.js
+++ b/doofinder-for-woocommerce/assets/js/wizard.js
@@ -69,8 +69,9 @@ jQuery(() => {
   window.addEventListener(
     "message",
     (event) => {
+      const doofinder_regex = /.*\.doofinder\.com/gm;
       //Check that the sender is doofinder
-      if (event.origin !== doofinderAdminPath) return;
+      if (!doofinder_regex.test(event.origin)) return;
       if (event.data) {
         data = event.data.split("|");
         event_name = data[0];
@@ -82,14 +83,7 @@ jQuery(() => {
   );
 
   function processMessage(name, data) {
-    switch (name) {
-      case "set_doofinder_data":
-        send_connect_data(data);
-        break;
-
-      default:
-        break;
-    }
+    if (name === "set_doofinder_data") send_connect_data(data);
   }
 
   function send_connect_data(data) {
@@ -99,24 +93,29 @@ jQuery(() => {
       dataType: "json",
       url: DoofinderForWC.ajaxUrl,
       data: data,
-    }).then((response) => {
-      if (response.success) {
-        confirmLeavePage(false);
-        window.location.href = doofinderSetupWizardUrl;
-        return;
-      } else {
-        $(".errors-wrapper ul").remove();
-        if (response.errors) {
-          errors = "<ul>";
-          for (er in response.errors) {
-            error = response.errors[er];
-            errors += "<li>" + error + "</li>";
-          }
-          errors += "</ul>";
-          $(".errors-wrapper").append(errors);
-          $(".errors-wrapper").show();
+      success: function (response) {
+        if (response.success) {
+          confirmLeavePage(false);
+          window.location.href = doofinderSetupWizardUrl;
+          return;
+        } else {
+          set_errors(response.errors);
         }
-      }
+      },
     });
+  }
+
+  function set_errors(errors) {
+    $(".errors-wrapper ul").remove();
+    if (errors) {
+      errors_html = "<ul>";
+      for (er in errors) {
+        error = errors[er];
+        errors_html += "<li>" + error + "</li>";
+      }
+      errors_html += "</ul>";
+      $(".errors-wrapper").append(errors_html);
+      $(".errors-wrapper").show();
+    }
   }
 });

--- a/doofinder-for-woocommerce/assets/js/wizard.js
+++ b/doofinder-for-woocommerce/assets/js/wizard.js
@@ -2,7 +2,6 @@ jQuery(() => {
   const $ = jQuery.noConflict();
 
   let connectModal;
-  let checkInterval;
 
   const popupCenter = ({ url, title, w, h }) => {
     const dualScreenLeft =
@@ -48,52 +47,7 @@ jQuery(() => {
       window.onbeforeunload = () => null;
     }
   };
-  /*
-  const ajaxCheckData = () => {
-    jQuery
-      .ajax({
-        type: "POST",
-        dataType: "json",
-        url: DoofinderForWC.ajaxUrl,
-        data: { action: "doofinder_for_wc_check_data" },
-      })
-      .then((response) => {
-        if (!response.success) {
-          console.error("ajaxCheckData - Something went wrong");
-          return;
-        }
 
-        console.info("ajaxCheckData - Status: " + response.data.status);
-
-        if (
-          response.data.status !== "saved" &&
-          response.data.status !== "error"
-        ) {
-          console.info("ajaxCheckData - checking again...");
-          return;
-        }
-
-        $(".errors-wrapper ul").remove();
-        if (response.data.status === "error") {
-          errors = "<ul>";
-          for (er in response.data.error) {
-            error = response.data.error[er];
-            errors += "<li>" + error + "</li>";
-          }
-          errors += "</ul>";
-          $(".errors-wrapper").append(errors);
-          $(".errors-wrapper").show();
-        }
-
-        if (response.data.status === "saved") {
-          clearInterval(checkInterval);
-          confirmLeavePage(false);
-          console.info("ajaxCheckData - reloading page...");
-          window.location.href = doofinderSetupWizardUrl;
-        }
-      });
-  };
-*/
   $("#doofinder-for-wc-index-button").click(() => {
     const progressBarWrapper = $(".dfwc-setup-step__progress-bar-wrapper").get(
       0
@@ -104,27 +58,19 @@ jQuery(() => {
 
   $(".open-window").click((e) => {
     const pageType = $(e.currentTarget).attr("data-type");
-    doofinderAdminEndpoint = "https://pedro-doomanager.ngrok.doofinder.com";
-
     connectModal = popupCenter({
-      url: `${doofinderAdminEndpoint}/plugins/${pageType}/woocommerce?email=${doofinderConnectEmail}&token=${doofinderConnectToken}`,
+      url: `${doofinderAdminPath}/plugins/${pageType}/woocommerce?email=${doofinderConnectEmail}&token=${doofinderConnectToken}`,
       title: "DoofinderConnect",
       w: 600,
       h: 700,
     });
-
-    //clearInterval(checkInterval);
-    //checkInterval = setInterval(ajaxCheckData, 1000);
   });
 
   window.addEventListener(
     "message",
     (event) => {
-      // Do we trust the sender of this message?  (might be
-      // different from what we originally opened, for example).
-      if (event.origin !== doofinderAdminEndpoint) return;
-      console.log(event.source, "Source");
-      console.log(event.data, "data");
+      //Check that the sender is doofinder
+      if (event.origin !== doofinderAdminPath) return;
       if (event.data) {
         data = event.data.split("|");
         event_name = data[0];
@@ -138,8 +84,6 @@ jQuery(() => {
   function processMessage(name, data) {
     switch (name) {
       case "set_doofinder_data":
-        console.log("Send ajax request to save the doofinder connection data");
-        console.log(data);
         send_connect_data(data);
         break;
 
@@ -150,31 +94,29 @@ jQuery(() => {
 
   function send_connect_data(data) {
     data["action"] = "doofinder_set_connection_data";
-    jQuery
-      .ajax({
-        type: "POST",
-        dataType: "json",
-        url: DoofinderForWC.ajaxUrl,
-        data: data,
-      })
-      .then((response) => {
-        if (response.success) {
-          confirmLeavePage(false);
-          window.location.href = doofinderSetupWizardUrl;
-          return;
-        } else {
-          $(".errors-wrapper ul").remove();
-          if (response.errors) {
-            errors = "<ul>";
-            for (er in response.errors) {
-              error = response.errors[er];
-              errors += "<li>" + error + "</li>";
-            }
-            errors += "</ul>";
-            $(".errors-wrapper").append(errors);
-            $(".errors-wrapper").show();
+    $.ajax({
+      type: "POST",
+      dataType: "json",
+      url: DoofinderForWC.ajaxUrl,
+      data: data,
+    }).then((response) => {
+      if (response.success) {
+        confirmLeavePage(false);
+        window.location.href = doofinderSetupWizardUrl;
+        return;
+      } else {
+        $(".errors-wrapper ul").remove();
+        if (response.errors) {
+          errors = "<ul>";
+          for (er in response.errors) {
+            error = response.errors[er];
+            errors += "<li>" + error + "</li>";
           }
+          errors += "</ul>";
+          $(".errors-wrapper").append(errors);
+          $(".errors-wrapper").show();
         }
-      });
+      }
+    });
   }
 });

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder for WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 1.5.27
+ * Version: 1.5.28
  * Author: doofinder
  * Description: Integrate Doofinder Search in your WooCommerce shop.
  *
@@ -50,7 +50,7 @@ if (
              *
              * @var string
              */
-            public static $version = '1.5.27';
+            public static $version = '1.5.28';
 
             /**
              * The only instance of Doofinder_For_WooCommerce

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -153,15 +153,6 @@ if (
                     Post::register_rest_api_webhooks();
                 }
 
-                // Register custom WP REST Api endpoint
-                add_action('rest_api_init', function () use ($class) {
-                    register_rest_route('doofinder-for-wc/v1', '/connect/', array(
-                        'methods' => ['POST', 'GET'],
-                        'callback' => array($class, 'connect'),
-                        'permission_callback' => '__return_true'
-                    ));
-                });
-
                 // Some functionalities need to be initialized on both admin side, and frontend.
                 Both_Sides::instance();
                 Add_To_Cart::instance();

--- a/doofinder-for-woocommerce/includes/class-add-to-cart.php
+++ b/doofinder-for-woocommerce/includes/class-add-to-cart.php
@@ -51,7 +51,15 @@ class Add_To_Cart
     public static function product_info()
     {
         $post_id = $_REQUEST['id'] ?? NULL;
+        if (empty($post_id)) {
+            return '';
+        }
+
         $product = wc_get_product($post_id);
+        if (empty($product)) {
+            return '';
+        }
+
         $variation_id = 0;
 
         if (is_a($product, 'WC_Product_Variation')) {

--- a/doofinder-for-woocommerce/includes/class-add-to-cart.php
+++ b/doofinder-for-woocommerce/includes/class-add-to-cart.php
@@ -41,23 +41,16 @@ class Add_To_Cart
 
         add_action('wp_ajax_doofinder_ajax_add_to_cart',  array(__CLASS__, 'doofinder_ajax_add_to_cart'));
         add_action('wp_ajax_nopriv_doofinder_ajax_add_to_cart',  array(__CLASS__, 'doofinder_ajax_add_to_cart'));
-
-        // Register custom WP REST Api endpoint
-        add_action('rest_api_init', function () {
-            register_rest_route('doofinder-for-wc/v1', '/product-info/(?P<id>\d+)', array(
-                'methods' => ['GET'],
-                'callback' => array(__CLASS__, 'product_info'),
-                'permission_callback' => '__return_true'
-            ));
-        });
+        add_action('wp_ajax_doofinder_get_product_info',  array(__CLASS__, 'product_info'));
+        add_action('wp_ajax_nopriv_doofinder_get_product_info',  array(__CLASS__, 'product_info'));
     }
 
     /**
-     * Callback for WP Rest Api item-info endpoint
+     * Returns the product info for a given id
      */
-    public static function product_info(\WP_REST_Request $request)
+    public static function product_info()
     {
-        $post_id = $request->get_param("id");
+        $post_id = $_REQUEST['id'] ?? NULL;
         $product = wc_get_product($post_id);
         $variation_id = 0;
 

--- a/doofinder-for-woocommerce/includes/class-setup-wizard.php
+++ b/doofinder-for-woocommerce/includes/class-setup-wizard.php
@@ -205,7 +205,7 @@ class Setup_Wizard
 	 * 
 	 * @var string
 	 */
-	const ADMIN_PATH = 'https://app.doofinder.com';
+	const ADMIN_PATH = 'https://admin.doofinder.com';
 
 
 	public function __construct()
@@ -1314,7 +1314,7 @@ class Setup_Wizard
 	{
 		$api_key = $_REQUEST['api_token'] ?? null;
 		$api_host = $_REQUEST['api_endpoint'] ?? null; // i.e: eu1-api.doofinder.com for API v2.0
-		$admin_endpoint = $_REQUEST['admin_endpoint'] ?? null; // i.e: eu1-app.doofinder.com for API v2.0
+		$admin_endpoint = $_REQUEST['admin_endpoint'] ?? null; // i.e: eu1-admin.doofinder.com for API v2.0
 		$search_endpoint = $_REQUEST['search_endpoint'] ?? null; // i.e: eu1-search.doofinder.com for API v2.0
 
 		if (empty($api_key)) {
@@ -1608,10 +1608,10 @@ class Setup_Wizard
 		}
 
 		// Check and update admin endpoint
-		$admin_endpoint_base = '-app.doofinder.com';
+		$admin_endpoint_base = '-admin.doofinder.com';
 		$admin_endpoint = Settings::get_admin_endpoint();
 
-		if (!$admin_endpoint || !preg_match("@$api_host_prefix-app@", $admin_endpoint || !preg_match("#^((https?://)|www\.?)#i", $admin_endpoint))) {
+		if (!$admin_endpoint || !preg_match("@$api_host_prefix-admin@", $admin_endpoint || !preg_match("#^((https?://)|www\.?)#i", $admin_endpoint))) {
 			$log->log('Migrate - Set Admin Endpoint');
 			Settings::set_admin_endpoint('https://' . $api_host_prefix . $admin_endpoint_base);
 		}

--- a/doofinder-for-woocommerce/includes/class-setup-wizard.php
+++ b/doofinder-for-woocommerce/includes/class-setup-wizard.php
@@ -4,25 +4,16 @@ namespace Doofinder\WC;
 
 use Doofinder\WC\Multilanguage\Language_Plugin;
 use Doofinder\WC\Multilanguage\Multilanguage;
-use Doofinder\WC\Multilanguage as Multilang;
-
 use Doofinder\WC\Settings\Settings;
-use Doofinder\WC\Helpers\Template_Engine;
 use Doofinder\WC\Helpers\Helpers;
 use Doofinder\Management\ManagementClient;
 use Doofinder\WC\Log;
-use Doofinder\WC\Api\Api_Factory;
 use Doofinder\WC\Api\Api_Wrapper;
-use Doofinder\WC\Api\Api_Status;
 use Doofinder\WC\Index_Interface;
-
 use Doofinder\GuzzleHttp\Client as GuzzleClient;
-
-use Error;
 use Doofinder\Management\Errors\DoofinderError;
 use Doofinder\WC\Api\Store_Api;
 use Exception;
-use WP_REST_Response;
 
 class Setup_Wizard
 {

--- a/doofinder-for-woocommerce/includes/class-setup-wizard.php
+++ b/doofinder-for-woocommerce/includes/class-setup-wizard.php
@@ -205,7 +205,7 @@ class Setup_Wizard
 	 * 
 	 * @var string
 	 */
-	const ADMIN_PATH = 'https://admin.doofinder.com';
+	const ADMIN_PATH = 'https://app.doofinder.com';
 
 
 	public function __construct()
@@ -1314,7 +1314,7 @@ class Setup_Wizard
 	{
 		$api_key = $_REQUEST['api_token'] ?? null;
 		$api_host = $_REQUEST['api_endpoint'] ?? null; // i.e: eu1-api.doofinder.com for API v2.0
-		$admin_endpoint = $_REQUEST['admin_endpoint'] ?? null; // i.e: eu1-admin.doofinder.com for API v2.0
+		$admin_endpoint = $_REQUEST['admin_endpoint'] ?? null; // i.e: eu1-app.doofinder.com for API v2.0
 		$search_endpoint = $_REQUEST['search_endpoint'] ?? null; // i.e: eu1-search.doofinder.com for API v2.0
 
 		if (empty($api_key)) {
@@ -1608,10 +1608,10 @@ class Setup_Wizard
 		}
 
 		// Check and update admin endpoint
-		$admin_endpoint_base = '-admin.doofinder.com';
+		$admin_endpoint_base = '-app.doofinder.com';
 		$admin_endpoint = Settings::get_admin_endpoint();
 
-		if (!$admin_endpoint || !preg_match("@$api_host_prefix-admin@", $admin_endpoint || !preg_match("#^((https?://)|www\.?)#i", $admin_endpoint))) {
+		if (!$admin_endpoint || !preg_match("@$api_host_prefix-app@", $admin_endpoint || !preg_match("#^((https?://)|www\.?)#i", $admin_endpoint))) {
 			$log->log('Migrate - Set Admin Endpoint');
 			Settings::set_admin_endpoint('https://' . $api_host_prefix . $admin_endpoint_base);
 		}

--- a/doofinder-for-woocommerce/includes/class-setup-wizard.php
+++ b/doofinder-for-woocommerce/includes/class-setup-wizard.php
@@ -209,6 +209,13 @@ class Setup_Wizard
 	 */
 	public static $should_fail = false;
 
+	/**
+	 * Admin path used to get the connection details
+	 * 
+	 * @var string
+	 */
+	const ADMIN_PATH = 'https://app.doofinder.com';
+
 
 	public function __construct()
 	{
@@ -441,20 +448,13 @@ class Setup_Wizard
 	 */
 	public function getReturnPath()
 	{
-
-		/*
-		$setup_wizard_url = get_site_url(null, 'wp-content/plugins/doofinder-for-woocommerce/api/connect/');
-		$blog_id = get_current_blog_id();
-		$setup_wizard_url .= $blog_id === 1 ? "": "?site_id=".$blog_id;
-		*/
-
 		$setup_wizard_url = get_site_url(null, 'wp-json/doofinder-for-wc/v1/connect/');
 		return $setup_wizard_url;
 	}
 
 	public function getAdminPath()
 	{
-		return  "https://app.doofinder.com";
+		return self::ADMIN_PATH;
 	}
 
 	/**
@@ -994,7 +994,7 @@ class Setup_Wizard
 		}
 
 		// Check if api key and api host is valid, make test call to API
-		if ($this->test_api_settings($api_settings)) {
+		if ($this->test_api_settings($api_settings, $step)) {
 			extract($api_settings);
 			$this->remove_wizard_step_error($step, 'api-endpoint-connection-failed');
 			$this->remove_wizard_step_error($step, 'api-endpoint');
@@ -1394,28 +1394,28 @@ class Setup_Wizard
 		return true;
 	}
 
-	private function test_api_settings($api_settings)
+	private function test_api_settings($api_settings, $step)
 	{
 		extract($api_settings);
 
 		if (!$this->disable_api) {
 			try {
 				$client = new ManagementClient($api_host, $api_key);
-				$this->log->log('Wizard Step 2 - Call Api - List search engines ');
-				$this->log->log('Wizard Step 2 - API key: ' . $api_key);
-				$this->log->log('Wizard Step 2 - API host: ' . $api_host);
+				$this->log->log('Wizard Step ' . $step . ' - Call Api - List search engines ');
+				$this->log->log('Wizard Step ' . $step . ' - API key: ' . $api_key);
+				$this->log->log('Wizard Step ' . $step . ' - API host: ' . $api_host);
 
 				$response = $client->listSearchEngines();
-				$this->log->log('Wizard Step 2 - List Search engines Response: ');
+				$this->log->log('Wizard Step ' . $step . ' - List Search engines Response: ');
 				$this->log->log($response);
 
-				$this->log->log('Wizard Step 2 - List search engines - success ');
+				$this->log->log('Wizard Step ' . $step . ' - List search engines - success ');
 				return true;
 			} catch (\DoofinderManagement\ApiException $exception) {
-				$this->log->log('Wizard Step 2: ' . $exception->getMessage());
-				$this->add_wizard_step_error(2, 'api-endpoint-connection-failed', __('Could not connect to the API. API Key or Host is not valid.', 'woocommerce-doofinder'));
+				$this->log->log('Wizard Step ' . $step . ': ' . $exception->getMessage());
+				$this->add_wizard_step_error($step, 'api-endpoint-connection-failed', __('Could not connect to the API. API Key or Host is not valid.', 'woocommerce-doofinder'));
 			} catch (\Exception $exception) {
-				$this->log->log('Wizard Step 2 - Exception ');
+				$this->log->log('Wizard Step ' . $step . ' - Exception ');
 				$this->log->log($exception);
 
 				if ($exception instanceof DoofinderError) {

--- a/doofinder-for-woocommerce/includes/class-setup-wizard.php
+++ b/doofinder-for-woocommerce/includes/class-setup-wizard.php
@@ -452,6 +452,11 @@ class Setup_Wizard
 		return $setup_wizard_url;
 	}
 
+	public function getAdminPath()
+	{
+		return  "https://app.doofinder.com";
+	}
+
 	/**
 	 * What the current step of the wizard is? This is the last step
 	 * that the user have seen and not submitted yet.
@@ -1011,7 +1016,6 @@ class Setup_Wizard
 	 */
 	private function process_step_3($is_ajax = false, $data = null)
 	{
-		return;
 		$is_processing = isset($_REQUEST['process_step']) && $_REQUEST['process_step'] === '3';
 
 		if (!$is_processing) {
@@ -1322,7 +1326,6 @@ class Setup_Wizard
 		$admin_endpoint = $_REQUEST['admin_endpoint'] ?? null; // i.e: eu1-app.doofinder.com for API v2.0
 		$search_endpoint = $_REQUEST['search_endpoint'] ?? null; // i.e: eu1-search.doofinder.com for API v2.0
 
-		$api_host = '//aaa.com';
 		if (empty($api_key)) {
 			$this->add_wizard_step_error($step, 'api-key', __('API key is missing.', 'woocommerce-doofinder'));
 		} else {

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder for WooCommerce ===
 Contributors: doofinder
 Tags: search, autocomplete, woocommerce
-Version: 1.5.27
+Version: 1.5.28
 Requires at least: 5.0
 Tested up to: 6.0
 Requires PHP: 5.6
@@ -126,6 +126,9 @@ You can click *Delete* to remove the additional attributes from the feed.
 Just send your questions to <mailto:support@doofinder.com> and we will try to answer as fast as possible with a working solution for you.
 
 == Changelog ==
+
+= 1.5.28 =
+Fixed issues while connecting to doofinder in Setup Wizard
 
 = 1.5.27 =
 Bugfixes

--- a/doofinder-for-woocommerce/views/wizard.php
+++ b/doofinder-for-woocommerce/views/wizard.php
@@ -49,6 +49,7 @@ $wp_styles = wp_styles();
         ?>
         const doofinderConnectToken = '<?php echo $token; ?>';
         const doofinderConnectReturnPath = '<?php echo $this->getReturnPath(); ?>';
+        const doofinderAdminPath = '<?php echo $this->getAdminPath(); ?>';
         const doofinderSetupWizardUrl = '<?php echo $this->get_url(); ?>';
     </script>
     <script src="<?php echo $wp_scripts->base_url . $wp_scripts->registered['jquery-core']->src; ?>"></script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "1.5.27",
+  "version": "1.5.28",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The goal of this PR is to avoid some 4xx errors while doing requests to the wp-rest api.
- I've replaced the previous wp-rest endpoint callback to connect with doofinder after login with a postmessage sent from the login window.
- I've also replaced the add_to_cart product info wp-rest endpoint with an admin-ajax call.