### PR TITLE
Removed unwanted error logs that were being displayed

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder for WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 1.5.28
+ * Version: 1.5.29
  * Author: doofinder
  * Description: Integrate Doofinder Search in your WooCommerce shop.
  *
@@ -44,13 +44,19 @@ if (
          */
         class Doofinder_For_WooCommerce
         {
+            /**
+             * Previous error level.
+             *
+             * @var int
+             */
+            public static $prev_errors;
 
             /**
              * Plugin version.
              *
              * @var string
              */
-            public static $version = '1.5.28';
+            public static $version = '1.5.29';
 
             /**
              * The only instance of Doofinder_For_WooCommerce
@@ -157,7 +163,6 @@ if (
                 Both_Sides::instance();
                 Add_To_Cart::instance();
 
-                self::maybe_suppress_notices();
             }
 
             /**
@@ -177,8 +182,16 @@ if (
              */
             public static function maybe_suppress_notices()
             {
-                if (is_ssl() || getenv('APP_ENV') === 'production') {
-                    error_reporting(E_ALL & ~E_NOTICE);
+                if (is_ssl() || getenv('APP_ENV') === 'production' && !isset(static::$prev_errors)) {
+                    static::$prev_errors = error_reporting();
+                    error_reporting(static::$prev_errors & ~E_NOTICE);
+                }
+            }
+
+            public static function maybe_restore_notices()
+            {                
+                if (is_ssl() || getenv('APP_ENV') === 'production' && isset(static::$prev_errors)) {
+                    error_reporting(static::$prev_errors);                    
                 }
             }
 

--- a/doofinder-for-woocommerce/includes/class-data-feed.php
+++ b/doofinder-for-woocommerce/includes/class-data-feed.php
@@ -313,6 +313,7 @@ class Data_Feed {
 	 * @since 1.0.0
 	 */
 	public function generate() {
+		Doofinder_For_WooCommerce::maybe_suppress_notices();
 		header( 'Content-Type: text/plain' );
 		//header( 'Content-Type: text/html' );
 
@@ -325,8 +326,8 @@ class Data_Feed {
 			$this->add_products();
 			$this->render();
 		}
-
 		echo '';
+		Doofinder_For_WooCommerce::maybe_restore_notices();
 	}
 
 

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder for WooCommerce ===
 Contributors: doofinder
 Tags: search, autocomplete, woocommerce
-Version: 1.5.28
+Version: 1.5.29
 Requires at least: 5.0
 Tested up to: 6.0
 Requires PHP: 5.6
@@ -126,6 +126,9 @@ You can click *Delete* to remove the additional attributes from the feed.
 Just send your questions to <mailto:support@doofinder.com> and we will try to answer as fast as possible with a working solution for you.
 
 == Changelog ==
+
+= 1.5.29 =
+Fixed a bug that caused unwanted error logs to be displayed
 
 = 1.5.28 =
 Fixed issues while connecting to doofinder in Setup Wizard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "1.5.28",
+  "version": "1.5.29",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Until now, the error level was modified at the level of the entire web, which caused the client's error_level to be replaced with E_ALL & ~E_NOTICE (All except notices).
This caused errors such as E_DEPRECATED to be enabled throughout the web.
To fix this, I've modified the **maybe_suppress_notices** function so that, based on the client's error_level, it removes the notices.
On the other hand, that function is no longer executed every time the plugin loads, but is called only when generating the feed, which is where it is needed.
Lastly, I've created another function, **maybe_restore_notices**, which resets the previous value with the intention of calling it after the feed is generated.