### PR TITLE
Fix sale_price in update on save

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder for WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 1.5.38
+ * Version: 1.5.39
  * Author: doofinder
  * Description: Integrate Doofinder Search in your WooCommerce shop.
  *
@@ -56,7 +56,7 @@ if (
              *
              * @var string
              */
-            public static $version = '1.5.38';
+            public static $version = '1.5.39';
 
             /**
              * The only instance of Doofinder_For_WooCommerce

--- a/doofinder-for-woocommerce/lib/src/Management/ManagementClient.php
+++ b/doofinder-for-woocommerce/lib/src/Management/ManagementClient.php
@@ -585,7 +585,7 @@ class ManagementClient {
      * @return \DoofinderManagement\Model\Item
      */
     public function updateItem($hashid, $item_id, $name, $body) {
-        try {            
+        try {
             return $this->ItemsClient->itemCreate($body, $hashid, $name, $item_id);
         } catch (ApiException $e) {
             $statusCode = $e->getCode();

--- a/doofinder-for-woocommerce/lib/src/Management/ManagementClient.php
+++ b/doofinder-for-woocommerce/lib/src/Management/ManagementClient.php
@@ -569,7 +569,13 @@ class ManagementClient {
     }
 
     /**
-     * Partially updates an item in the index.
+     * Updates an item in the index.
+     * 
+     * We call itemCreate instead of itemUpdate because itemUpdate uses PATCH 
+     * method what causes an issue when the special_price is being removed.
+     * The sale_price property never gets removed.
+     * 
+     * Using POST instead, removes this issue, as it completely updates the item.
      *
      * @param  string $hashid Unique id of a search engine. (required)
      * @param  string $item_id Unique identifier of an item inside an index. (required)
@@ -579,8 +585,8 @@ class ManagementClient {
      * @return \DoofinderManagement\Model\Item
      */
     public function updateItem($hashid, $item_id, $name, $body) {
-        try {
-            return $this->ItemsClient->itemUpdate($body, $hashid, $name, $item_id);
+        try {            
+            return $this->ItemsClient->itemCreate($body, $hashid, $name, $item_id);
         } catch (ApiException $e) {
             $statusCode = $e->getCode();
             $contentResponse = $e->getResponseBody();

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder for WooCommerce ===
 Contributors: doofinder
 Tags: search, autocomplete, woocommerce
-Version: 1.5.38
+Version: 1.5.39
 Requires at least: 5.0
 Tested up to: 6.1
 Requires PHP: 5.6
@@ -126,6 +126,9 @@ You can click *Delete* to remove the additional attributes from the feed.
 Just send your questions to <mailto:support@doofinder.com> and we will try to answer as fast as possible with a working solution for you.
 
 == Changelog ==
+
+= 1.5.39 =
+Fixed a bug with update on save while removing the sale_price
 
 = 1.5.38 =
 Fixed a bug with multilanguage indexation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "1.5.38",
+  "version": "1.5.39",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR solves an issue when you try to remove the sale_price of a product.

I've changed the method used to update the product from updateItem to createItem, as createItem uses post instead of patch method in order to remove the fields we want (special_price)