### PR TITLE
Use locale code instead of language

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder for WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 1.5.40
+ * Version: 1.5.41
  * Author: doofinder
  * Description: Integrate Doofinder Search in your WooCommerce shop.
  *
@@ -56,7 +56,7 @@ if (
              *
              * @var string
              */
-            public static $version = '1.5.40';
+            public static $version = '1.5.41';
 
             /**
              * The only instance of Doofinder_For_WooCommerce

--- a/doofinder-for-woocommerce/includes/api/class-store-api.php
+++ b/doofinder-for-woocommerce/includes/api/class-store-api.php
@@ -49,10 +49,11 @@ class Store_Api
     public function create_store($api_keys)
     {
         if (is_array($api_keys)) {
-            $primary_language = explode("_", get_locale())[0];
+            $primary_language = get_locale();
             if ($this->language->is_active()) {
                 $primary_language = $this->language->get_base_language();
             }
+            $primary_language = $this->format_language_code($primary_language);
 
             $domain = str_ireplace('www.', '', parse_url(get_bloginfo('url'), PHP_URL_HOST));
 
@@ -67,7 +68,9 @@ class Store_Api
 
             foreach ($api_keys as $item) {
                 if ($item['hash'] === 'no-hash') {
-                    $code = $item['lang']['code'] ?? $primary_language;
+                    //Prioritize the locale code
+                    $code = $item['lang']['locale'] ?? $item['lang']['code'] ?? $primary_language;
+                    $code = $this->format_language_code($code);
                     // Prepare search engine body
                     $this->log->log('Wizard Step 2 - Prepare Search Enginge body : ');
                     $store_data["search_engines"][] = [
@@ -117,4 +120,9 @@ class Store_Api
             throw new Exception("Error #{$response->getStatusCode()} creating store structure. $body", $response->getStatusCode());
         }
     }
+
+    public function format_language_code($code)
+	{
+		return str_replace('_', '-', $code);
+	}
 }

--- a/doofinder-for-woocommerce/includes/class-data-feed.php
+++ b/doofinder-for-woocommerce/includes/class-data-feed.php
@@ -162,6 +162,8 @@ class Data_Feed {
 	 */
 	private function load_products($product_ids = null, $language = null) {
 		global $woocommerce;
+
+		$language = Helpers::get_language_from_locale($language);
 		
 		$this->log->log('Load products');
 

--- a/doofinder-for-woocommerce/includes/class-data-index.php
+++ b/doofinder-for-woocommerce/includes/class-data-index.php
@@ -444,10 +444,12 @@ class Data_Index
 
 		$languages = $this->language->get_languages();
 
+		$this->languages = [''];
 		if (is_array($languages)) {
-			$this->languages = array_keys($languages);
-		} else {
-			$this->languages = [''];
+			$this->languages = [];
+			foreach ($languages as $key => $value) {
+				$this->languages[] = $value['locale'];
+			}
 		}
 
 		// if we start indexing, then language is not set, so we get first language from list
@@ -794,6 +796,8 @@ class Data_Index
 			$this->log->log('Calculate Progress - current lang: "' . $lang . '"');
 		}
 
+		$lang = Helpers::get_language_from_locale($lang);
+
 		$query = "";
 
 		if (!$lang || !$sitepress) {
@@ -923,7 +927,7 @@ class Data_Index
 				$query .= "LEFT JOIN {$wpdb->prefix}icl_translations
 				ON $wpdb->posts.ID = {$wpdb->prefix}icl_translations.element_id
 				WHERE $wpdb->posts.post_type IN ($indexed_post_types_list)
-				AND {$wpdb->prefix}icl_translations.language_code='{$this->indexing_data->get('lang')}'
+				AND {$wpdb->prefix}icl_translations.language_code='{$lang}'
 				";
 			} else {
 				$query .= "
@@ -970,7 +974,7 @@ class Data_Index
 					LEFT JOIN {$wpdb->prefix}icl_translations
 					ON $wpdb->posts.ID = {$wpdb->prefix}icl_translations.element_id
 					WHERE " . $post_type_query . "
-					AND {$wpdb->prefix}icl_translations.language_code='{$this->indexing_data->get('lang')}'
+					AND {$wpdb->prefix}icl_translations.language_code='{$lang}'
 				";
 			} else {
 				$query .= "

--- a/doofinder-for-woocommerce/includes/class-data-index.php
+++ b/doofinder-for-woocommerce/includes/class-data-index.php
@@ -447,8 +447,8 @@ class Data_Index
 		$this->languages = [''];
 		if (is_array($languages)) {
 			$this->languages = [];
-			foreach ($languages as $key => $value) {
-				$this->languages[] = $value['locale'];
+			foreach ($languages as $language) {
+				$this->languages[] = $language['locale'];
 			}
 		}
 

--- a/doofinder-for-woocommerce/includes/class-index-interface.php
+++ b/doofinder-for-woocommerce/includes/class-index-interface.php
@@ -234,7 +234,7 @@ class Index_Interface {
 			$api_keys_array = [];
 
 			foreach($language->get_languages() as $lang) {
-				$code = $lang['code'];
+				$code = $lang['locale'];
 				$code = $code === $language->get_base_language() ? '' : $code;
 				$hash = Settings::get_search_engine_hash($code);
 				$hash = !$hash ? 'no-hash' : $hash;

--- a/doofinder-for-woocommerce/includes/class-setup-wizard.php
+++ b/doofinder-for-woocommerce/includes/class-setup-wizard.php
@@ -1635,7 +1635,7 @@ class Setup_Wizard
 			$currency_key = strtoupper($currency);
 			//format language to en_US instead of en-US format			
 			$language_key = Helpers::format_locale_to_underscore($language);
-			$is_primary_language = strtolower($this->language->get_base_language()) == strtolower($language_key);
+			$is_primary_language = strtolower($this->language->get_base_language()) === strtolower($language_key);
 			if (!property_exists($search_engine, $currency)) {
 				$currency_key = strtolower($currency);
 			}

--- a/doofinder-for-woocommerce/includes/class-setup-wizard.php
+++ b/doofinder-for-woocommerce/includes/class-setup-wizard.php
@@ -1633,8 +1633,9 @@ class Setup_Wizard
 		$currency = get_woocommerce_currency();
 		foreach ($search_engines as $language => $search_engine) {
 			$currency_key = strtoupper($currency);
-			$language_key = $language;
-			$is_primary_language = strtolower($this->language->get_base_language()) == strtolower($language);
+			//format language to en_US instead of en-US format			
+			$language_key = Helpers::format_locale_to_underscore($language);
+			$is_primary_language = strtolower($this->language->get_base_language()) == strtolower($language_key);
 			if (!property_exists($search_engine, $currency)) {
 				$currency_key = strtolower($currency);
 			}
@@ -1678,6 +1679,8 @@ class Setup_Wizard
 			// Enable JS Layer			
 			Settings::enable_js_layer($options_suffix);
 
+			//Convert language to hyphen format used by live layer (en-US)
+			$language_code = Helpers::format_locale_to_hyphen($language_code);
 			$lang_config = "language: '$language_code',\n    currency: '$currency',\n    installationId:";
 			$aux_script  = !empty($language_code) ? str_replace("installationId:", $lang_config, $script) : $script;
 

--- a/doofinder-for-woocommerce/includes/class-update-manager.php
+++ b/doofinder-for-woocommerce/includes/class-update-manager.php
@@ -180,4 +180,42 @@ class Update_Manager
 
 		return true;
 	}
+
+	/**
+	 * Update: 1.5.41
+	 * Update the plugin options with new language codes (en_US) instead of (en)
+	 */
+	public static function update_010541()
+	{
+		$options_to_update = [
+			"woocommerce_doofinder_internal_search_hashid_",
+			"woocommerce_doofinder_internal_search_enable_",
+			"woocommerce_doofinder_layer_enabled_",
+			"woocommerce_doofinder_layer_code_",
+			"woocommerce_doofinder_last_modified_index_",
+		];
+		$multilanguage = Multilanguage::instance();
+		$languages = $multilanguage->get_languages();
+		$sites = get_sites();
+
+		foreach ($sites as $key => $site) {
+			// Switch to another blog			
+			switch_to_blog($site->blog_id);
+			foreach ($languages as $lang_code => $language) {
+				foreach ($options_to_update as $key => $option) {
+					$key_to_update = $option . $lang_code;
+					$current_value = get_option($key_to_update, "_NOT_FOUND_");
+					if ($current_value  != "_NOT_FOUND_") {
+						$new_option_key = $option . $language['locale'];
+						update_option($new_option_key, $current_value);
+					}
+				}
+			}
+			// Restore previous blog
+			// https://developer.wordpress.org/reference/functions/restore_current_blog/#more-information
+			restore_current_blog();
+		}
+
+		return true;
+	}
 }

--- a/doofinder-for-woocommerce/includes/class-update-manager.php
+++ b/doofinder-for-woocommerce/includes/class-update-manager.php
@@ -194,19 +194,23 @@ class Update_Manager
 			"woocommerce_doofinder_layer_code_",
 			"woocommerce_doofinder_last_modified_index_",
 		];
-		$multilanguage = Multilanguage::instance();
-		$languages = $multilanguage->get_languages();
 		$sites = get_sites();
 
 		foreach ($sites as $key => $site) {
 			// Switch to another blog			
 			switch_to_blog($site->blog_id);
+			// If WPML is not installed ignore the update for this site
+			if (!function_exists('icl_get_languages')) {
+				continue;
+			}
+
+			$languages = Helpers::getSiteLanguages($site->blog_id);
 			foreach ($languages as $lang_code => $language) {
 				foreach ($options_to_update as $key => $option) {
 					$key_to_update = $option . $lang_code;
 					$current_value = get_option($key_to_update, "_NOT_FOUND_");
 					if ($current_value  != "_NOT_FOUND_") {
-						$new_option_key = $option . $language['locale'];
+						$new_option_key = $option . $language['default_locale'];
 						update_option($new_option_key, $current_value);
 					}
 				}

--- a/doofinder-for-woocommerce/includes/class-update-manager.php
+++ b/doofinder-for-woocommerce/includes/class-update-manager.php
@@ -180,46 +180,4 @@ class Update_Manager
 
 		return true;
 	}
-
-	/**
-	 * Update: 1.5.41
-	 * Update the plugin options with new language codes (en_US) instead of (en)
-	 */
-	public static function update_010541()
-	{
-		$options_to_update = [
-			"woocommerce_doofinder_internal_search_hashid_",
-			"woocommerce_doofinder_internal_search_enable_",
-			"woocommerce_doofinder_layer_enabled_",
-			"woocommerce_doofinder_layer_code_",
-			"woocommerce_doofinder_last_modified_index_",
-		];
-		$sites = get_sites();
-
-		foreach ($sites as $key => $site) {
-			// Switch to another blog			
-			switch_to_blog($site->blog_id);
-			// If WPML is not installed ignore the update for this site
-			if (!function_exists('icl_get_languages')) {
-				continue;
-			}
-
-			$languages = Helpers::getSiteLanguages($site->blog_id);
-			foreach ($languages as $lang_code => $language) {
-				foreach ($options_to_update as $key => $option) {
-					$key_to_update = $option . $lang_code;
-					$current_value = get_option($key_to_update, "_NOT_FOUND_");
-					if ($current_value  != "_NOT_FOUND_") {
-						$new_option_key = $option . $language['default_locale'];
-						update_option($new_option_key, $current_value);
-					}
-				}
-			}
-			// Restore previous blog
-			// https://developer.wordpress.org/reference/functions/restore_current_blog/#more-information
-			restore_current_blog();
-		}
-
-		return true;
-	}
 }

--- a/doofinder-for-woocommerce/includes/helpers/class-helpers.php
+++ b/doofinder-for-woocommerce/includes/helpers/class-helpers.php
@@ -103,36 +103,4 @@ class Helpers
     {
         return str_replace("_", "-", $locale_code);
     }
-
-    /**
-     * Unfortunately while updating we can't obtain the languages for each site 
-     * with our own methods, so we have to make a query to get the available 
-     * languages for each site.
-     *
-     * @param int $blog_id
-     * @return array Available languages for the given blog_id
-     */
-    public static function getSiteLanguages($blog_id)
-    {
-        $blog_languages = array();
-        global $wpdb;
-        $blog_id = $blog_id == 1 ? '' :  $blog_id;
-
-        $query_blog_id = $blog_id == '' ? '' :  $blog_id . "_";
-
-        $QUERY  = $wpdb->prepare('SELECT code,  default_locale FROM ' . $wpdb->base_prefix . $query_blog_id . 'icl_languages WHERE active =  %d', 1) . PHP_EOL;
-        $result = $wpdb->get_results($QUERY);
-
-        $blog_languages = [];
-        if (!empty($result)) {
-            foreach ($result as $key2 => $langObj) {
-                $blog_languages[$langObj->code] = [
-                    'code' => $langObj->code,
-                    'default_locale' => $langObj->default_locale,
-                ];
-            }
-        }
-
-        return $blog_languages;
-    }
 }

--- a/doofinder-for-woocommerce/includes/helpers/class-helpers.php
+++ b/doofinder-for-woocommerce/includes/helpers/class-helpers.php
@@ -103,4 +103,36 @@ class Helpers
     {
         return str_replace("_", "-", $locale_code);
     }
+
+    /**
+     * Unfortunately while updating we can't obtain the languages for each site 
+     * with our own methods, so we have to make a query to get the available 
+     * languages for each site.
+     *
+     * @param int $blog_id
+     * @return array Available languages for the given blog_id
+     */
+    public static function getSiteLanguages($blog_id)
+    {
+        $blog_languages = array();
+        global $wpdb;
+        $blog_id = $blog_id == 1 ? '' :  $blog_id;
+
+        $query_blog_id = $blog_id == '' ? '' :  $blog_id . "_";
+
+        $QUERY  = $wpdb->prepare('SELECT code,  default_locale FROM ' . $wpdb->base_prefix . $query_blog_id . 'icl_languages WHERE active =  %d', 1) . PHP_EOL;
+        $result = $wpdb->get_results($QUERY);
+
+        $blog_languages = [];
+        if (!empty($result)) {
+            foreach ($result as $key2 => $langObj) {
+                $blog_languages[$langObj->code] = [
+                    'code' => $langObj->code,
+                    'default_locale' => $langObj->default_locale,
+                ];
+            }
+        }
+
+        return $blog_languages;
+    }
 }

--- a/doofinder-for-woocommerce/includes/helpers/class-helpers.php
+++ b/doofinder-for-woocommerce/includes/helpers/class-helpers.php
@@ -4,42 +4,46 @@ namespace Doofinder\WC\Helpers;
 
 use Doofinder\WC\Settings\Settings;
 
-class Helpers {
+class Helpers
+{
 
     /**
      * Returns `true` if we are currently in debug mode, `false` otherwise.
      *
      * @return bool
      */
-    public static function is_debug_mode() {
+    public static function is_debug_mode()
+    {
         return Settings::get_enable_debug_mode();
     }
 
     /**
      * Check if string contains https:// if not then add it
      */
-    public static function prepare_host($host) {
-        if($host) {
-            $has_http = preg_match('@^http[s]?:\/\/@',$host);
+    public static function prepare_host($host)
+    {
+        if ($host) {
+            $has_http = preg_match('@^http[s]?:\/\/@', $host);
             $host = !$has_http ? 'https://' . $host : $host;
         }
         return $host;
     }
 
-    public static function get_memory_usage($real = false, $peak = false, $in_megabytes = false) {
-        
+    public static function get_memory_usage($real = false, $peak = false, $in_megabytes = false)
+    {
+
         $unit = $in_megabytes ? ' MB' : ' bytes';
         $megabyte = 1048576;
 
         if ($peak) {
-            $amount = $in_megabytes ? round(memory_get_peak_usage($real)/$megabyte,2) : number_format(memory_get_peak_usage($real), 0, ',', ' '); 
-            $amount_in_mb = round(memory_get_peak_usage($real)/$megabyte,2);
+            $amount = $in_megabytes ? round(memory_get_peak_usage($real) / $megabyte, 2) : number_format(memory_get_peak_usage($real), 0, ',', ' ');
+            $amount_in_mb = round(memory_get_peak_usage($real) / $megabyte, 2);
         } else {
-            $amount = $in_megabytes ? round(memory_get_usage($real)/$megabyte,2) : number_format(memory_get_usage($real), 0, ',', ' ');
-            $amount_in_mb = round(memory_get_usage($real)/$megabyte,2);
+            $amount = $in_megabytes ? round(memory_get_usage($real) / $megabyte, 2) : number_format(memory_get_usage($real), 0, ',', ' ');
+            $amount_in_mb = round(memory_get_usage($real) / $megabyte, 2);
         }
 
-        return $amount . $unit . ' ' . ' ('. $amount_in_mb.' MB)';
+        return $amount . $unit . ' ' . ' (' . $amount_in_mb . ' MB)';
     }
 
     /**
@@ -47,8 +51,9 @@ class Helpers {
      *
      * @return bool
      */
-    public static function in_array_r($needle, $haystack, $strict = false) {
-       
+    public static function in_array_r($needle, $haystack, $strict = false)
+    {
+
         foreach ($haystack as $item) {
             if (($strict ? $item === $needle : $item == $needle) || (is_array($item) && self::in_array_r($needle, $item, $strict))) {
 
@@ -56,5 +61,46 @@ class Helpers {
             }
         }
         return false;
+    }
+
+    /**
+     * This function extracts the language code from a language country code.
+     * Example: 'en-US' or 'en_US' is converted to to ISO 639-1 language code
+     * en.
+     *
+     * @param string $language_code
+     * @return string The language code
+     */
+    public static function get_language_from_locale($language_code)
+    {
+        $language_code = str_replace("-", "_", $language_code);
+        return explode("_", $language_code)[0];
+    }
+
+
+
+    /**
+     * This function converts a locale code (language and country code) from 
+     * 'en-US' to 'en_US' format.
+     *
+     * @param string $locale_code
+     * @return string The formatted locale code
+     */
+    public static function format_locale_to_underscore($locale_code)
+    {
+        return str_replace("-", "_", $locale_code);
+    }
+
+
+    /**
+     * This function converts a locale code (language and country code) from 
+     * 'en_US' to 'en-US' format used by Live Layer.
+     *
+     * @param string $locale_code
+     * @return string The formatted locale code
+     */
+    public static function format_locale_to_hyphen($locale_code)
+    {
+        return str_replace("_", "-", $locale_code);
     }
 }

--- a/doofinder-for-woocommerce/includes/multilanguage/class-wpml.php
+++ b/doofinder-for-woocommerce/includes/multilanguage/class-wpml.php
@@ -2,6 +2,7 @@
 
 namespace Doofinder\WC\Multilanguage;
 
+use Doofinder\WC\Helpers\Helpers;
 use Doofinder\WC\Log;
 use Doofinder\WC\Settings\Settings;
 
@@ -73,7 +74,21 @@ class WPML implements I18n_Handler
 	{
 		global $sitepress;
 
-		return $sitepress->get_default_language();
+		$lang_code = $sitepress->get_default_language();		
+		return $this->languages[$lang_code]['locale'];
+	}
+
+
+	public function get_base_locale()
+	{
+		global $sitepress;
+
+		$lang_code = $sitepress->get_default_language();		
+		return $this->languages[$lang_code]['locale'];
+	}
+
+	public function get_locale_by_lang_code($lang_code){
+		return $this->languages[$lang_code]['locale'];
 	}
 
 	/**
@@ -91,6 +106,9 @@ class WPML implements I18n_Handler
 			if ($lang === 'all') {
 				return '';
 			}
+
+			//get locale code
+			$lang = $this->get_locale_by_lang_code($lang);
 
 			return $lang;
 		}
@@ -186,7 +204,8 @@ class WPML implements I18n_Handler
 		// For example 'en' => 'English'.
 		$formatted_languages = array();
 		foreach ($languages as $key => $value) {
-			$formatted_languages[$key] = $value['translated_name'];
+			$language_code = $value['default_locale'];
+			$formatted_languages[$language_code] = $value['translated_name'];
 		}
 
 		return $formatted_languages;
@@ -215,6 +234,7 @@ class WPML implements I18n_Handler
 		global $wpdb;
 		global $sitepress;
 
+		$language_code = Helpers::get_language_from_locale($language_code);
 		$split_variable_lang = $sitepress ? 'all' : '';
 
 		// Set post types to query depending on split_variable option
@@ -282,6 +302,9 @@ class WPML implements I18n_Handler
 		if ($language_code === $base_language) {
 			return $base;
 		}
+
+		//Replace hyphens with underscores in language code		
+		$language_code = Helpers::format_locale_to_underscore($language_code);
 
 		return "{$base}_{$language_code}";
 	}

--- a/doofinder-for-woocommerce/includes/multilanguage/class-wpml.php
+++ b/doofinder-for-woocommerce/includes/multilanguage/class-wpml.php
@@ -304,7 +304,7 @@ class WPML implements I18n_Handler
 		}
 
 		//Replace hyphens with underscores in language code		
-		$language_code = Helpers::format_locale_to_underscore($language_code);
+		$language_code = Helpers::get_language_from_locale($language_code);
 
 		return "{$base}_{$language_code}";
 	}

--- a/doofinder-for-woocommerce/includes/multilanguage/class-wpml.php
+++ b/doofinder-for-woocommerce/includes/multilanguage/class-wpml.php
@@ -49,6 +49,7 @@ class WPML implements I18n_Handler
 				'active' => $active_language['active'] ?? '',
 				'default' => $is_default,
 				'prefix' => ($is_default ? '' : ($active_language['code'] ?? '')),
+				'locale' => $active_language['default_locale'] ?? ''
 			);
 
 			$this->languages[$active_language['code']] = $language;

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder for WooCommerce ===
 Contributors: doofinder
 Tags: search, autocomplete, woocommerce
-Version: 1.5.40
+Version: 1.5.41
 Requires at least: 5.0
 Tested up to: 6.1
 Requires PHP: 5.6
@@ -126,6 +126,9 @@ You can click *Delete* to remove the additional attributes from the feed.
 Just send your questions to <mailto:support@doofinder.com> and we will try to answer as fast as possible with a working solution for you.
 
 == Changelog ==
+
+= 1.5.41 =
+Updated to use language country codes
 
 = 1.5.40 =
 Fixed a bug that made some images to be resized in the client's platform

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "1.5.40",
+  "version": "1.5.41",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Now we send the full locale code (en-US) instead of the language code (en) to the create-store endpoint.