### PR TITLE
Replaced arrow functions by anonymous functions

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder for WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 1.5.45
+ * Version: 1.5.46
  * Author: doofinder
  * Description: Integrate Doofinder Search in your WooCommerce shop.
  *
@@ -57,7 +57,7 @@ if (
              *
              * @var string
              */
-            public static $version = '1.5.45';
+            public static $version = '1.5.46';
 
             /**
              * The only instance of Doofinder_For_WooCommerce

--- a/doofinder-for-woocommerce/includes/data-feed/class-data-feed-item.php
+++ b/doofinder-for-woocommerce/includes/data-feed/class-data-feed-item.php
@@ -511,7 +511,9 @@ class Data_Feed_Item
 		$stock_by_attribute = $this->get_stock_by_attribute($variations);
 
 		foreach ($stock_by_attribute as $attribute => $values) {
-			$keys_without_stock = array_keys(array_filter($values, fn ($value) => $value === false));
+			$keys_without_stock = array_keys(array_filter($values, function ($value) {
+				return $value === false;
+			}));
 			if (empty($keys_without_stock)) {
 				continue;
 			}
@@ -519,7 +521,9 @@ class Data_Feed_Item
 			$attribute = str_replace("pa_", "", $attribute);
 			//We need to replace double slashes by another character in order to avoid errors when exploding by single slashes
 			$new_attributes = explode("/", str_replace("//", "@SLASH@", $this->fields[$attribute]));
-			$new_attributes = array_map(fn ($value) => str_replace('@SLASH@', '/', $value), $new_attributes);
+			$new_attributes = array_map(function ($value) {
+				return str_replace('@SLASH@', '/', $value);
+			}, $new_attributes);
 			foreach ($keys_without_stock as $value) {
 				$pos = array_search($value, $new_attributes);
 				if ($pos !== false) {
@@ -528,7 +532,9 @@ class Data_Feed_Item
 			}
 			if (!empty($new_attributes)) {
 				//Replace single slashes with a custom marker
-				$new_attributes = array_map(fn ($value) => str_replace('/', '@SLASH@', $value), $new_attributes);
+				$new_attributes = array_map(function ($value) {
+					return str_replace('/', '@SLASH@', $value);
+				}, $new_attributes);
 				//Implode by slashes and replace the custom marker with double slashes
 				$this->fields[$attribute] = str_replace('@SLASH@', '//', implode('/', $new_attributes));
 			} else {

--- a/doofinder-for-woocommerce/includes/settings/class-attributes.php
+++ b/doofinder-for-woocommerce/includes/settings/class-attributes.php
@@ -204,7 +204,7 @@ class Attributes
 			$attribute = $attributes[$attribute_name];
 		} else {
 			$attributes = $product_object->get_attributes();
-			$attribute = $product_object->get_attribute( $attribute_name);
+			$attribute = $product_object->get_attribute($attribute_name);
 		}
 
 		if (empty($attribute)) {
@@ -213,7 +213,9 @@ class Attributes
 		// Doofinder requires attributes to be separated by `/`.
 		// @see https://www.doofinder.com/support/the-data-feed/facets
 		if (is_array($attribute)) {
-			$attribute = array_map(fn ($value): string => str_replace('/', '//', $value), $attribute);
+			$attribute = array_map(function ($value) {
+				return str_replace('/', '//', $value);
+			}, $attribute);
 			return implode('/', $attribute);
 		} else {
 			return str_replace('/', '//', $attribute);

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder for WooCommerce ===
 Contributors: doofinder
 Tags: search, autocomplete, woocommerce
-Version: 1.5.45
+Version: 1.5.46
 Requires at least: 5.0
 Tested up to: 6.1
 Requires PHP: 5.6
@@ -126,6 +126,9 @@ You can click *Delete* to remove the additional attributes from the feed.
 Just send your questions to <mailto:support@doofinder.com> and we will try to answer as fast as possible with a working solution for you.
 
 == Changelog ==
+
+= 1.5.46 =
+Fixed some issues with PHP version
 
 = 1.5.45 =
 Fixed bug with woocommerce attributes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "1.5.45",
+  "version": "1.5.46",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
A client had some errors with arrow functions, as these were introduced in PHP 7.4, and they are using PHP 7.3
I've replaced arrow functions by anonymous functions