### PR TITLE
Fix indexing failed error message issues

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.0.1
+ * Version: 2.0.2
  * Author: Doofinder
  * Description: Integrate Doofinder Search in your WordPress site or WooCommerce shop.
  *
@@ -34,7 +34,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          *
          * @var string
          */
-        public static $version = '2.0.1';
+        public static $version = '2.0.2';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -362,8 +362,11 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
 
                         $error_message = $request->get_param('message');
                         if (!empty($error_message) && $error_message != $valid_message) {
+                            $notice_title = __("An error has occurred while indexing your catalog", "wordpress-doofinder");
+                            $notice_content = __("To obtain further details, you can check the indexing results by accessing the \"Indices\" section in your Doofinder admin panel. If the problem persists, please contact our support team at <a href=\"mailto:support@doofinder.com\">support@doofinder.com</a>", "wordpress-doofinder");                            
+                            //Dismiss the indexing notice as it has already finished
                             Setup_Wizard::dismiss_indexing_notice();
-                            Admin_Notices::add_notice("indexing-status-failed", __("The indexation failed", "wordpress-doofinder"), $error_message, 'error', null, '', true);
+                            Admin_Notices::add_notice("indexing-status-failed", $notice_title, $notice_content, 'error', null, '', true);
 
                             return new WP_REST_Response(
                                 [

--- a/doofinder-for-woocommerce/includes/class-update-manager.php
+++ b/doofinder-for-woocommerce/includes/class-update-manager.php
@@ -173,7 +173,7 @@ class Update_Manager
         //Update api host to point to admin.doofinder.com instead of api.doofinder.com
         $multilanguage = Multilanguage::instance();
         $languages = $multilanguage->get_languages();
-        if(empty($languages)){
+        if (empty($languages)) {
             $languages = ['' => []];
         }
 
@@ -196,5 +196,14 @@ class Update_Manager
             $store_api->normalize_store_and_indices();
         }
         return true;
+    }
+
+    /**
+     * Update: 2.0.2
+     * Remove the indexing failed notice to solve any existing problem
+     */
+    public static function update_020002()
+    {
+        Admin_Notices::remove_notice("indexing-status-failed");
     }
 }

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.0.1
+Version: 2.0.2
 Requires at least: 4.1
 Tested up to: 6.1
 Requires PHP: 5.6
@@ -81,6 +81,9 @@ General Settings
 Just send your questions to <mailto:support@doofinder.com> and we will try to answer as fast as possible with a working solution for you.
 
 == Changelog ==
+
+= 2.0.2 =
+Fix a bug while showing the indexation failed message
 
 = 2.0.1 =
 Fix a bug in settings migration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Requested-by: [support/issues/1179](https://github.com/doofinder/support/issues/1179)
We have discovered an issue with the indexation result response. 
When an error occurs, Doofeeds returns the whole body of a 404 response.
Example:
```
[download][product] something went wrong with feed download, Wordpress: a problem has occurred in the web server. \n\n<!DOCTYPE html>\n\n<html lang=\"pt-PT\" class=\"supports-fontface\">\n\n<head>\n\t<meta charset=\"UTF-8\">\n\t<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no\" />\n\t<meta name=\"apple-itunes-app\" content=\"app-id=1580786296\">\n\t<meta name=\"facebook-domain-verification\" content=\"m4rzd3s3cozqzah2jev9uqvdzjtqwh\" />\n\n\t<link rel=\"pingback\" href=\"https://lojasdavisao.pt/xmlrpc.php\">\n\t<link rel=\"profile\" href=\"//gmpg.org/xfn/11\">...
```
This leads us to render the whole 404 page HTML inside the Indexing notice content, causing serious problems in the WP backend.
To solve this, we have replaced the message coming from Doofeeds with a static message.