### PR TITLE
UNPLUGGED-1204 | Added a way to show prices with the correct taxes in the REST API

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -122,15 +122,6 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
                 JS_Layer::instance();
             }
 
-            add_action( 'rest_api_init', function() {
-                add_filter( 'woocommerce_product_get_regular_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
-                add_filter( 'woocommerce_product_get_sale_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
-                add_filter( 'woocommerce_product_get_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
-                add_filter( 'woocommerce_product_variation_get_regular_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
-                add_filter( 'woocommerce_product_variation_get_sale_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
-                add_filter( 'woocommerce_product_variation_get_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
-            } );
-
             add_action('init', function () use ($class) {
                 // Register all custom URLs
                 call_user_func(array($class, 'register_urls'));
@@ -400,6 +391,12 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
         {
             add_action('rest_api_init', function () {
                 Config::register();
+                add_filter( 'woocommerce_product_get_regular_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+                add_filter( 'woocommerce_product_get_sale_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+                add_filter( 'woocommerce_product_get_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+                add_filter( 'woocommerce_product_variation_get_regular_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+                add_filter( 'woocommerce_product_variation_get_sale_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+                add_filter( 'woocommerce_product_variation_get_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
                 register_rest_route('doofinder/v1', '/index-status', array(
                     'methods' => 'POST',
                     'callback' => function (\WP_REST_Request $request) {

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -126,6 +126,9 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
                 add_filter( 'woocommerce_product_get_regular_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
                 add_filter( 'woocommerce_product_get_sale_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
                 add_filter( 'woocommerce_product_get_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+                add_filter( 'woocommerce_product_variation_get_regular_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+                add_filter( 'woocommerce_product_variation_get_sale_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+                add_filter( 'woocommerce_product_variation_get_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
             } );
 
             add_action('init', function () use ($class) {

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -16,6 +16,7 @@ namespace Doofinder\WP;
 use WP_REST_Response;
 use Doofinder\WP\Multilanguage\Multilanguage;
 use Doofinder\WP\Admin_Notices;
+use Doofinder\WP\Tax_Prices_Handler;
 
 defined('ABSPATH') or die;
 
@@ -160,58 +161,6 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
             if (is_admin()) {
                 Admin_Notices::init();
             }
-        }
-
-        public static function filter_woocommerce_prices_with_taxes( $price, $product ) {
-            // Only affects the prices shown on the REST API requests
-            if ( ! function_exists( 'WC' ) || ! WC()->is_rest_api_request() ) {
-                return $price;
-            }
-
-            // Just in case the sale price has not been defined, we're going to use the price instead
-            if ( empty( $price ) ) {
-                return $product->price;
-            }
-
-            $raw_real_price = self::get_raw_real_price( $price, $product );
-            // Idea extracted directly from the original WC function wc_price()
-            $args = array();
-            $args = apply_filters(
-                'wc_price_args',
-                wp_parse_args(
-                    $args,
-                    array(
-                        'ex_tax_label'       => false,
-                        'currency'           => '',
-                        'decimal_separator'  => wc_get_price_decimal_separator(),
-                        'thousand_separator' => wc_get_price_thousand_separator(),
-                        'decimals'           => wc_get_price_decimals(),
-                        'price_format'       => get_woocommerce_price_format(),
-                    )
-                )
-            );
-            $price = apply_filters( 'formatted_woocommerce_price', number_format( $raw_real_price, $args['decimals'], $args['decimal_separator'], $args['thousand_separator'] ), $price, $args['decimals'], $args['decimal_separator'], $args['thousand_separator'], $price );
-            if ( apply_filters( 'woocommerce_price_trim_zeros', false ) && $args['decimals'] > 0 ) {
-                $price = wc_trim_zeros( $price );
-            }
-            return $price;
-        } 
-
-        private static function get_raw_real_price( $price, $product ) {
-            $woocommerce_tax_display_shop = get_option( 'woocommerce_tax_display_shop', 'incl' );
-            return 'incl' === $woocommerce_tax_display_shop ?
-                wc_get_price_including_tax(
-                    $product,
-                    array(
-                        'price' => $price,
-                    )
-                ) :
-                wc_get_price_excluding_tax(
-                    $product,
-                    array(
-                        'price' => $price,
-                    )
-                );
         }
 
         /**
@@ -396,12 +345,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
         {
             add_action('rest_api_init', function () {
                 Config::register();
-                add_filter( 'woocommerce_product_get_regular_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
-                add_filter( 'woocommerce_product_get_sale_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
-                add_filter( 'woocommerce_product_get_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
-                add_filter( 'woocommerce_product_variation_get_regular_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
-                add_filter( 'woocommerce_product_variation_get_sale_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
-                add_filter( 'woocommerce_product_variation_get_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+                Tax_Prices_Handler::apply_correct_taxes_for_product_prices_in_rest_api();
                 register_rest_route('doofinder/v1', '/index-status', array(
                     'methods' => 'POST',
                     'callback' => function (\WP_REST_Request $request) {

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.0.4
+ * Version: 2.0.5
  * Author: Doofinder
  * Description: Integrate Doofinder Search in your WordPress site or WooCommerce shop.
  *
@@ -35,7 +35,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          *
          * @var string
          */
-        public static $version = '2.0.4';
+        public static $version = '2.0.5';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -122,6 +122,12 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
                 JS_Layer::instance();
             }
 
+            add_action( 'rest_api_init', function() {
+                add_filter( 'woocommerce_product_get_regular_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+                add_filter( 'woocommerce_product_get_sale_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+                add_filter( 'woocommerce_product_get_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+            } );
+
             add_action('init', function () use ($class) {
                 // Register all custom URLs
                 call_user_func(array($class, 'register_urls'));
@@ -160,6 +166,53 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
             if (is_admin()) {
                 Admin_Notices::init();
             }
+        }
+
+        public static function filter_woocommerce_prices_with_taxes( $price, $product ) {
+            // Only affects the prices shown on the REST API requests
+            if ( ! function_exists( 'WC' ) || ! WC()->is_rest_api_request() ) {
+                return $price;
+            }
+
+            $raw_real_price = self::get_raw_real_price( $price, $product );
+            // Idea extracted directly from the original WC function wc_price()
+            $args = array();
+            $args = apply_filters(
+                'wc_price_args',
+                wp_parse_args(
+                    $args,
+                    array(
+                        'ex_tax_label'       => false,
+                        'currency'           => '',
+                        'decimal_separator'  => wc_get_price_decimal_separator(),
+                        'thousand_separator' => wc_get_price_thousand_separator(),
+                        'decimals'           => wc_get_price_decimals(),
+                        'price_format'       => get_woocommerce_price_format(),
+                    )
+                )
+            );
+            $price = apply_filters( 'formatted_woocommerce_price', number_format( $raw_real_price, $args['decimals'], $args['decimal_separator'], $args['thousand_separator'] ), $price, $args['decimals'], $args['decimal_separator'], $args['thousand_separator'], $price );
+            if ( apply_filters( 'woocommerce_price_trim_zeros', false ) && $args['decimals'] > 0 ) {
+                $price = wc_trim_zeros( $price );
+            }
+            return $price;
+        } 
+
+        private static function get_raw_real_price( $price, $product ) {
+            $woocommerce_tax_display_shop = get_option( 'woocommerce_tax_display_shop', 'incl' );
+            return 'incl' === $woocommerce_tax_display_shop ?
+                wc_get_price_including_tax(
+                    $product,
+                    array(
+                        'price' => $price,
+                    )
+                ) :
+                wc_get_price_excluding_tax(
+                    $product,
+                    array(
+                        'price' => $price,
+                    )
+                );
         }
 
         /**

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -168,6 +168,11 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
                 return $price;
             }
 
+            // Just in case the sale price has not been defined, we're going to use the price instead
+            if ( empty( $price ) ) {
+                return $product->price;
+            }
+
             $raw_real_price = self::get_raw_real_price( $price, $product );
             // Idea extracted directly from the original WC function wc_price()
             $args = array();

--- a/doofinder-for-woocommerce/includes/class-tax-prices-handler.php
+++ b/doofinder-for-woocommerce/includes/class-tax-prices-handler.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Doofinder\WP;
+
+class Tax_Prices_Handler {
+
+    public static function apply_correct_taxes_for_product_prices_in_rest_api(): void {
+        add_filter( 'woocommerce_product_get_regular_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+        add_filter( 'woocommerce_product_get_sale_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+        add_filter( 'woocommerce_product_get_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+        add_filter( 'woocommerce_product_variation_get_regular_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+        add_filter( 'woocommerce_product_variation_get_sale_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+        add_filter( 'woocommerce_product_variation_get_price', array( __CLASS__, 'filter_woocommerce_prices_with_taxes' ), 99, 2 );
+    }
+
+    public static function filter_woocommerce_prices_with_taxes( $price, $product ) {
+        // Only affects the prices shown on the REST API requests
+        if ( ! function_exists( 'WC' ) || ! WC()->is_rest_api_request() ) {
+            return $price;
+        }
+
+        // Just in case the sale price has not been defined, we're going to use the price instead
+        if ( empty( $price ) ) {
+            return $product->price;
+        }
+
+        $raw_real_price = self::get_raw_real_price( $price, $product );
+        // Idea extracted directly from the original WC function wc_price()
+        $args = array();
+        $args = apply_filters(
+            'wc_price_args',
+            wp_parse_args(
+                $args,
+                array(
+                    'ex_tax_label'       => false,
+                    'currency'           => '',
+                    'decimal_separator'  => wc_get_price_decimal_separator(),
+                    'thousand_separator' => wc_get_price_thousand_separator(),
+                    'decimals'           => wc_get_price_decimals(),
+                    'price_format'       => get_woocommerce_price_format(),
+                )
+            )
+        );
+        $price = apply_filters( 'formatted_woocommerce_price', number_format( $raw_real_price, $args['decimals'], $args['decimal_separator'], $args['thousand_separator'] ), $price, $args['decimals'], $args['decimal_separator'], $args['thousand_separator'], $price );
+        if ( apply_filters( 'woocommerce_price_trim_zeros', false ) && $args['decimals'] > 0 ) {
+            $price = wc_trim_zeros( $price );
+        }
+        return $price;
+    } 
+
+    private static function get_raw_real_price( $price, $product ) {
+        $woocommerce_tax_display_shop = get_option( 'woocommerce_tax_display_shop', 'incl' );
+        return 'incl' === $woocommerce_tax_display_shop ?
+            wc_get_price_including_tax(
+                $product,
+                array(
+                    'price' => $price,
+                )
+            ) :
+            wc_get_price_excluding_tax(
+                $product,
+                array(
+                    'price' => $price,
+                )
+            );
+    }
+}

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.0.4
+Version: 2.0.5
 Requires at least: 4.1
 Tested up to: 6.1
 Requires PHP: 5.6
@@ -81,6 +81,9 @@ General Settings
 Just send your questions to <mailto:support@doofinder.com> and we will try to answer as fast as possible with a working solution for you.
 
 == Changelog ==
+
+= 2.0.5 =
+Bugfix: Prices reflect the correct taxes now
 
 = 2.0.4 =
 Minor bugfix

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -3,7 +3,7 @@ Contributors: Doofinder
 Tags: search, autocomplete
 Version: 2.0.5
 Requires at least: 4.1
-Tested up to: 6.1
+Tested up to: 6.2.2
 Requires PHP: 5.6
 Stable tag: trunk
 License: GPLv2 or later

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by: https://github.com/doofinder/support/issues/1204

The prices are usually displayed in the correct way with the taxes applied as expected. However, the users can apply two inconsistent setting that might lead to errors, so there are 4 possible situations:
-  Yes, I will enter prices inclusive of tax + Display prices in the shop including tax --> consistent case, the price shown on the REST API will match the one shown on the shop:
![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/74d25960-c46c-4080-896e-83613fe1475f)
![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/b267ffcf-bc78-4413-9188-9193b1e2dc07)

- No, I will enter prices exclusive of tax +  Display prices in the shop excluding tax --> consistent case, almost the same as the previous case, the prices will match again, but in this case the taxes are excluded from both.

- Yes, I will enter prices inclusive of tax +Display prices in the shop excluding tax --> inconsistent case, the REST API prices will be considered as the ones with the taxes applied (the inputted ones) whereas the public one will be lower, since the price shown is the one without VAT:
![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/196bcb6f-efb4-4970-b15a-c21d87a6fa7f)

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/075667a8-4a24-4153-bc29-518d2ee36160)

-  No, I will enter prices exclusive of tax + Display prices in the shop including tax --> inconsistent case, the REST API prices will be considered as the ones without the taxes applied (the inputted ones) whereas the public one will be higher, since the price shown is the one with VAT:
![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/de68f970-f052-4827-9efe-01b47c1ab3b9)
![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/ca4dc924-eb34-4af1-b18a-f429a575589b)

Both inconsistencies are warned by Woocommerce itself:

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/61de0148-1afb-469e-9dda-8a006da3d737)

This PR solves this situation by applying the correct taxes and mimicking the behavior on the product template:

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/528cc4fa-af9f-4340-abf3-22b22a6be988)

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/45851617-c3d0-4152-81c2-58d2f005e3ad)

Even with variants!!

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/1ebce941-9236-40eb-8497-1654903e3275)

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/004a5588-e5e2-4925-b2bc-9b88961420c4)

