### PR TITLE
Fix visual bug in product data setting when array is null

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.0.16
+ * Version: 2.0.17
  * Author: Doofinder
  * Description: Integrate Doofinder Search in your WordPress site or WooCommerce shop.
  *
@@ -34,7 +34,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          *
          * @var string
          */
-        public static $version = '2.0.16';
+        public static $version = '2.0.17';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/settings/class-renderers.php
+++ b/doofinder-for-woocommerce/includes/settings/class-renderers.php
@@ -425,7 +425,7 @@ trait Renderers
 
                 <?php
                 $type = ($attribute !== null) ? $attribute['type'] : null;
-                if ($type === 'metafield' && $index != "new") : ?>
+                if ($type === 'metafield' && $index !== "new") : ?>
                     <input class="df-attribute-text" type="text" name="<?php echo $option_name; ?>[<?php echo $index; ?>][attribute]" <?php if ($attribute) : ?> value="<?php echo $attribute['attribute']; ?>" <?php endif; ?> />
                 <?php else : ?>
                     <select class="df-attribute-select df-select-2" name="<?php echo $option_name; ?>[<?php echo $index; ?>][attribute]" required>

--- a/doofinder-for-woocommerce/includes/settings/class-renderers.php
+++ b/doofinder-for-woocommerce/includes/settings/class-renderers.php
@@ -422,7 +422,10 @@ trait Renderers
         <tr>
             <td>
 
-                <?php if ($attribute['type'] === 'metafield' && $index != "new") : ?>
+
+                <?php
+                $type = ($attribute !== null) ? $attribute['type'] : null;
+                if ($type === 'metafield' && $index != "new") : ?>
                     <input class="df-attribute-text" type="text" name="<?php echo $option_name; ?>[<?php echo $index; ?>][attribute]" <?php if ($attribute) : ?> value="<?php echo $attribute['attribute']; ?>" <?php endif; ?> />
                 <?php else : ?>
                     <select class="df-attribute-select df-select-2" name="<?php echo $option_name; ?>[<?php echo $index; ?>][attribute]" required>

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.0.16
+Version: 2.0.17
 Requires at least: 4.1
 Tested up to: 6.2.2
 Requires PHP: 5.6
@@ -81,6 +81,9 @@ General Settings
 Just send your questions to <mailto:support@doofinder.com> and we will try to answer as fast as possible with a working solution for you.
 
 == Changelog ==
+
+= 2.0.17 =
+Fix visual bug in Product Data Settings.
 
 = 2.0.16 =
 Added Image Size selector to Product Data Settingsa and fixed 'update on save' issue.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.0.16",
+      "version": "2.0.17",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Before:
![image](https://github.com/doofinder/doofinder-woocommerce/assets/22339368/342f4cbf-6650-4596-893b-d7f44b336648)

