### PR TITLE
Change version for Wordpress 6.3

### DIFF
--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -3,7 +3,7 @@ Contributors: Doofinder
 Tags: search, autocomplete
 Version: 2.0.20
 Requires at least: 4.1
-Tested up to: 6.2.2
+Tested up to: 6.3.1
 Requires PHP: 5.6
 Stable tag: trunk
 License: GPLv2 or later


### PR DESCRIPTION
Required by https://github.com/doofinder/doofinder-woocommerce/issues/189
We have to change version in the next PR