### PR TITLE
Adjust non base location prices

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.0.22
+ * Version: 2.0.23
  * Author: Doofinder
  * Description: Integrate Doofinder Search in your WordPress site or WooCommerce shop.
  *
@@ -13,7 +13,6 @@
 
 namespace Doofinder\WP;
 
-use WP_REST_Response;
 use Doofinder\WP\Multilanguage\Multilanguage;
 use Doofinder\WP\Admin_Notices;
 
@@ -34,7 +33,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          *
          * @var string
          */
-        public static $version = '2.0.22';
+        public static $version = '2.0.23';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/class-rest-api-handler.php
+++ b/doofinder-for-woocommerce/includes/class-rest-api-handler.php
@@ -26,6 +26,14 @@ class REST_API_Handler
             foreach (self::PRODUCT_FIELDS as $field) {
                 register_rest_field(array('product', 'product_variation'), $field, ['get_callback' => array(REST_API_Handler::class, 'get_' . $field)]);
             }
+
+            /*
+            Return prices applying base location taxes
+            More info: https://github.com/woocommerce/woocommerce/wiki/How-Taxes-Work-in-WooCommerce#prices-including-tax---experimental-behavior
+            */
+            add_filter('woocommerce_adjust_non_base_location_prices', function ($value) {
+                return isset($_SERVER['HTTP_DOOFINDER_ORIGIN']) ? false : $value;
+            });
         }
     }
 

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.0.22
+Version: 2.0.23
 Requires at least: 4.1
 Tested up to: 6.3.1
 Requires PHP: 5.6
@@ -81,6 +81,9 @@ General Settings
 Just send your questions to <mailto:support@doofinder.com> and we will try to answer as fast as possible with a working solution for you.
 
 == Changelog ==
+
+= 2.0.23 =
+Added changes to return prices applying base location taxes.
 
 = 2.0.22 =
 Fix migration update in old clients.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.0.22",
+      "version": "2.0.23",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Requested-by: https://github.com/doofinder/support/issues/1359

We encountered inconsistencies with prices while indexing from our local environment and the production environment. The problem arises from the WooCommerce REST API, which returns prices based on the geolocation of the requester. In this case, our server is in Ireland, resulting in the application of Irish taxes (23% VAT) rather than the base location taxes (21% VAT), leading to different prices being returned.

Solution: Implement a filter to return prices applying the base location taxes when receiving requests from Doofinder.