### PR TITLE
Fix of several problems with migration when it is multi-language

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.0.24.1
+ * Version: 2.0.25
  * Author: Doofinder
  * Description: Integrate Doofinder Search in your WordPress site or WooCommerce shop.
  *
@@ -33,7 +33,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          *
          * @var string
          */
-        public static $version = '2.0.24.1';
+        public static $version = '2.0.25';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/class-store-api.php
+++ b/doofinder-for-woocommerce/includes/api/class-store-api.php
@@ -127,8 +127,12 @@ class Store_Api
                 $lang = '';
             }
 
-            $se_hashid = Settings::get_search_engine_hash($lang);
-            $payload['search_engines'][$se_hashid] = $search_engine['datatypes'][0]['datasources'][0]['options'];
+            if (isset($api_keys[$lang])) {
+                $se_hashid = $api_keys[$lang]['hash']; 
+                $payload['search_engines'][$se_hashid] = $search_engine['datatypes'][0]['datasources'][0]['options'];
+            } else {
+                $this->log->log("No search engine retrieved for the language - " . $lang);
+            }        
         }
 
         $this->log->log("Sending request to normalize indices.");

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.0.24.1
+Version: 2.0.25
 Requires at least: 4.1
 Tested up to: 6.3.1
 Requires PHP: 5.6
@@ -81,6 +81,9 @@ General Settings
 Just send your questions to <mailto:support@doofinder.com> and we will try to answer as fast as possible with a working solution for you.
 
 == Changelog ==
+
+= 2.0.25 =
+Fix of several problems with migration when it is multi-language
 
 = 2.0.24.1 =
 Fix log cleaning

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.0.24.1",
+  "version": "2.0.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.0.24.1",
+      "version": "2.0.25",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.0.24.1",
+  "version": "2.0.25",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I have detected several problems with the migration when it is multi-language

One of them is that there are times that the multi-language plugins do not assign a prefix to the default language, so they do not match in those cases. There is an easier way to see that it matches without using the prefix.