### PR TITLE
Fix zero prices in Rest API response

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.0.28
+ * Version: 2.0.29
  * Author: Doofinder
  * Description: Integrate Doofinder Search in your WordPress site or WooCommerce shop.
  *
@@ -33,7 +33,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          *
          * @var string
          */
-        public static $version = '2.0.28';
+        public static $version = '2.0.29';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/class-rest-api-handler.php
+++ b/doofinder-for-woocommerce/includes/class-rest-api-handler.php
@@ -85,6 +85,8 @@ class REST_API_Handler
         if (is_a($wc_product, 'WC_Product') && method_exists($wc_product, $fn_name)) {
             $price = $wc_product->$fn_name();
             $raw_price =  $price_name === "sale_price" && $price === "" ? "" : self::get_raw_real_price($price, $wc_product);
+            //If price is equal to 0, return an empty string
+            $raw_price = (0 == $raw_price) ? "" : $raw_price;
             return $raw_price;
         }
     }

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.0.28
+Version: 2.0.29
 Requires at least: 4.1
 Tested up to: 6.3.1
 Requires PHP: 5.6
@@ -81,6 +81,9 @@ General Settings
 Just send your questions to <mailto:support@doofinder.com> and we will try to answer as fast as possible with a working solution for you.
 
 == Changelog ==
+
+= 2.0.29 =
+Fix issues with zero prices.
 
 = 2.0.28 =
 Fix store payload in wordpress case

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.0.28",
+      "version": "2.0.29",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required-by:
- https://github.com/doofinder/support/issues/1628

One of our clients is having issues with sale prices, so I've added a condition that checks if the price is equal to '0' and returns an empty string instead.

This way the price will be ignored instead of indexing the product with a price of '0'.