### PR TITLE
PLUGINRANGERS-2015 | Properly decode HTML entities for attributes

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.2.0
+ * Version: 2.1.16
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -35,7 +35,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          *
          * @var string
          */
-        public static $version = '2.2.0';
+        public static $version = '2.1.16';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.1.15
+ * Version: 2.2.0
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -35,7 +35,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          *
          * @var string
          */
-        public static $version = '2.1.15';
+        public static $version = '2.2.0';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -721,7 +721,7 @@ class Endpoint_Product
                     //If is an atributte with taxonomy, i need to get taxonomy value
                     if(taxonomy_exists($attribute_name)){
                         $term = get_term_by('slug', $option, $attribute_name);
-                        $option = $term ? $term->name : '';
+                        $option = $term ? html_entity_decode( strip_tags( $term->name ) ) : '';
                     }
                     $custom_attributes[$attribute_slug][] = $option;
                 }

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.1.15
+Version: 2.2.0
 Requires at least: 5.6
 Tested up to: 6.3.1
 Requires PHP: 7.0
@@ -85,6 +85,9 @@ Just send your questions to <mailto:support@doofinder.com> and we will try to an
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.2.0 =
+Fixed wrongly decoded HTML entities for custom attributes
 
 = 2.1.15 =
 Improve JS and CSS secure load

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.2.0
+Version: 2.1.16
 Requires at least: 5.6
 Tested up to: 6.3.1
 Requires PHP: 7.0
@@ -86,8 +86,8 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
-= 2.2.0 =
-Fixed wrongly decoded HTML entities for custom attributes
+= 2.1.16 =
+Fixes wrongly decoded HTML entities for custom attributes (e.g. &amp; instead of &)
 
 = 2.1.15 =
 Improve JS and CSS secure load


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2015

With this PR, special HTML entities like `&amp;` will be properly encoded (e.g. `&amp;` as `&`).

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/8d586642-51ab-4b8e-87f3-a81d18941401)
