### PR TITLE
PLUGINRANGERS-2000 | Avoided 500 errors with WPML + simplified some ternary operators

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.1.16
+ * Version: 2.1.17
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -35,7 +35,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          *
          * @var string
          */
-        public static $version = '2.1.16';
+        public static $version = '2.1.17';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.1.16
+Version: 2.1.17
 Requires at least: 5.6
 Tested up to: 6.3.1
 Requires PHP: 7.0
@@ -85,6 +85,9 @@ Just send your questions to <mailto:support@doofinder.com> and we will try to an
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.1.17 =
+Fixes some issues detected if it is used along with WPML plugin
 
 = 2.1.16 =
 Fixes wrongly decoded HTML entities for custom attributes (e.g. &amp; instead of &)

--- a/doofinder-for-woocommerce/views/wizard-step.php
+++ b/doofinder-for-woocommerce/views/wizard-step.php
@@ -6,8 +6,8 @@ $wizard = Setup_Wizard::instance();
 
 $step = isset($step) ? $step : 1;
 $active = isset($active) ? $active : false;
-$active = $step === $step_state ? true : false;
-$finished = $step_state > $step ? true : false;
+$active = $step === $step_state;
+$finished = $step_state > $step;
 $error = $wizard->get_errors_html("wizard-step-$step");
 ?>
 <div class="df-setup-step df-setup-step-connect <?php echo $active ? 'active' : ''; ?> <?php echo !empty($error) ? 'has-error' : ''; ?> <?php echo $finished ? 'finished' : ''; ?>">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.1.16",
+  "version": "2.1.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.1.16",
+      "version": "2.1.17",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.1.16",
+  "version": "2.1.17",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2000

We have detected that our plugin can create some conflicts with the WPML one due to the rewrite rules applied for the landings, since WPML tries to rewrite the base in the .htaccess thus causing the issue. More info in: https://wpml.org/errata/htaccess-is-rewritten-with-language-folder/