### PR TITLE
PLUGINRANGERS-2014 | Prevent stock_status field removal

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.1.17
+ * Version: 2.1.18
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -35,7 +35,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          *
          * @var string
          */
-        public static $version = '2.1.17';
+        public static $version = '2.1.18';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -551,7 +551,7 @@ class Endpoint_Product
         else{
             $product["availability"] = "out of stock";
         }
-        unset($product["stock_status"]);
+
         return $product;
     }
 

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.1.17
+Version: 2.1.18
 Requires at least: 5.6
 Tested up to: 6.3.1
 Requires PHP: 7.0
@@ -85,6 +85,9 @@ Just send your questions to <mailto:support@doofinder.com> and we will try to an
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.1.18 =
+Prevent stock_status field removal from the final response
 
 = 2.1.17 =
 Fixes some issues detected if it is used along with WPML plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.1.17",
+      "version": "2.1.18",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2014

Some customers has some non-purchasable items (e.g. auction items), but they want to customize the template using the real stock status. This PR keeps the stock_status field in the response.