### PR TITLE
Fix sale price not indexing and custom_attribute not exporting

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.2.2
+ * Version: 2.2.3
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -36,7 +36,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          * @var string
          */
 
-        public static $version = '2.2.2';
+        public static $version = '2.2.3';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -247,7 +247,7 @@ class Endpoint_Product
             if (is_array($data_with_attr[$fieldKey])) {
                 $name_column = array_column($data_with_attr[$fieldKey], "name");
 
-                if (!$name_column) {
+                if (!empty($name_column)) {
                     $data_with_attr[$fieldKey] = $name_column;
                 }    
             }

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -393,8 +393,8 @@ class Endpoint_Product
     * @param array $product The product array to format prices.
     * @return array $product with formatted prices
     */
-   private static function format_prices($product)
-   {
+    private static function format_prices($product)
+    {
         $wc_product = wc_get_product($product["id"]);
 
         $regular_price = self::get_regular_price($wc_product);
@@ -406,7 +406,7 @@ class Endpoint_Product
         $product["sale_price"]    = $sale_price == "" && $price < $regular_price ? $price : $sale_price;
 
         return $product;
-   }
+    }
 
     /**
      * Returns the raw price for the given product.
@@ -420,6 +420,7 @@ class Endpoint_Product
         $fn_name = "get_$price_name";
         if (is_a($wc_product, 'WC_Product') && method_exists($wc_product, $fn_name)) {
             $price = $wc_product->$fn_name();
+            // If sale price is empty, do not attempt to get the raw real price, as we will get the original price
             $raw_price =  $price_name === "sale_price" && $price === "" ? "" : self::get_raw_real_price($price, $wc_product);
             //If price is equal to 0, return an empty string
             $raw_price = (0 == $raw_price) ? "" : $raw_price;

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -86,7 +86,8 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 = 2.2.3 =
-TODO
+Fix an issue that happened when a custom attribute had nested arrays without the key "name" deleting the whole custom attribute
+Get the sale price even when WC_Product->get_sale_price fails.
 
 = 2.2.2 =
 Fix an issue while setting search engine hashid and some notice styles issues.

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.2.2
+Version: 2.2.3
 Requires at least: 5.6
 Tested up to: 6.3.1
 Requires PHP: 7.0
@@ -85,6 +85,9 @@ Just send your questions to <mailto:support@doofinder.com> and we will try to an
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+= 2.2.3 =
+TODO
+
 = 2.2.2 =
 Fix an issue while setting search engine hashid and some notice styles issues.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",
@@ -355,6 +355,18 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/coffeescript": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
+      "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A==",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -2885,6 +2897,11 @@
       "version": "1.1.0",
       "dev": true,
       "optional": true
+    },
+    "coffeescript": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
+      "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A=="
     },
     "color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes issues https://github.com/doofinder/support/issues/2037 and https://github.com/doofinder/support/issues/2079

The first issue was caused by the code deleting all of the elements in the custom_attributes array if they didn't have the key "name". To fix it we check first if we are setting an empty array as the custom attrbiute, and if so we leave the original, full array. 

The second was caused by the wordpress funcion "get_sale_price" from WC_Product not returning a value. We believe this happens when a product has variants (https://stackoverflow.com/a/51065777). We are making a fix by calculating the sales price ourselves, looking at the regular price and the price.