### PR TITLE
[Bug] - Store created without a name

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.2.6
+ * Version: 2.2.7
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -36,7 +36,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          * @var string
          */
 
-        public static $version = '2.2.6';
+        public static $version = '2.2.7';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/class-store-api.php
+++ b/doofinder-for-woocommerce/includes/api/class-store-api.php
@@ -201,8 +201,11 @@ class Store_Api
     {
         $primary_language = $this->get_primary_language();
 
+        $name = get_bloginfo('name');
+        $store_name = !empty($name) ? $name : "Default Store";
+
         $store_payload = [
-            "name" =>  get_bloginfo('name'),
+            "name" =>  $store_name,
             "platform" =>  is_plugin_active('woocommerce/woocommerce.php') ? "woocommerce" : "wordpress",
             "primary_language" => $primary_language,
             "site_url" => get_bloginfo('url'),

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.2.6
+Version: 2.2.7
 Requires at least: 5.6
 Tested up to: 6.3.1
 Requires PHP: 7.0
@@ -85,6 +85,9 @@ Just send your questions to <mailto:support@doofinder.com> and we will try to an
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.2.7 =
+Fixed a bug that caused some stores to be created without a name.
 
 = 2.2.6 =
 Added minor improvements.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
As part of the [5949](https://github.com/doofinder/doomanager/issues/5949) task we want to minimize the probability of this type of error occurring, so we are going to make sure that we do not send the field empty. After talking with the product we have decided to name it "Default Store" for these cases. 

With this, there is still the second part of the task which is to increase the validity clauses controlling that the field is different from empty.