### PR TITLE
PLUGINRANGERS-2153 | Escaped all the slashes in attributes + changed Stable tag

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.2.9
+ * Version: 2.2.10
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -36,7 +36,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          * @var string
          */
 
-        public static $version = '2.2.9';
+        public static $version = '2.2.10';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -734,10 +734,10 @@ class Endpoint_Product
             if ($found_key !== false) {
                 $attribute_options = is_string($attribute_data) ? [$attribute_data] : $attribute_data->get_slugs();
                 foreach ($attribute_options as $option) {
-                    //If is an atributte with taxonomy, i need to get taxonomy value
+                    //If is an attribute with taxonomy, we need to get taxonomy value
                     if(taxonomy_exists($attribute_name)){
                         $term = get_term_by('slug', $option, $attribute_name);
-                        $option = $term ? html_entity_decode( strip_tags( $term->name ) ) : '';
+                        $option = $term ? preg_replace( '/(?<!\/)\/(?!\/)/', '//', html_entity_decode( strip_tags( $term->name ) ) ) : '';
                     }
                     $custom_attributes[$attribute_slug][] = $option;
                 }

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.2.9
+Version: 2.2.10
 Requires at least: 5.6
 Tested up to: 6.3.1
 Requires PHP: 7.0
-Stable tag: trunk
+Stable tag: 2.2.10
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Just send your questions to <mailto:support@doofinder.com> and we will try to an
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.2.10 =
+Changed stable tag information in the readme.txt
 
 = 2.2.9 =
 Changed log directory to /WP_CONTENT_FOLDER/uploads/doofinder-logs to avoid permission issues

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.2.9",
+      "version": "2.2.10",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2153

This PR adds an additional / if there is a single / in an attribute to fix the faceted search issue. It also fixes the Stable tag warning which was being shown on WP plugin repository:

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/892c8129-a1b2-45d9-ae13-1ffb6b1fc7ca)
(See 33//34)

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/391ba8e1-5c85-4eb6-8efd-834c9672d5b9)
