### PR TITLE
Store mysql db in a volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '2'
 services:
   db:
     image: mysql:5.7
+    volumes:
+      - wordpress-db:/var/lib/mysql
     restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
This was discussed here
https://github.com/doofinder/doofinder-woocommerce/issues/218#issuecomment-2003188290
Adding volume to store the wordpress database