### PR TITLE
PLUGINRANGERS-2305 | Fixed wpdb query on Update on Save

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.2.16
+ * Version: 2.2.17
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -36,7 +36,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          * @var string
          */
 
-        public static $version = '2.2.16';
+        public static $version = '2.2.17';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/class-update-on-save.php
+++ b/doofinder-for-woocommerce/includes/class-update-on-save.php
@@ -173,9 +173,9 @@ class Update_On_Save
 
         $table_name = $wpdb->prefix . 'doofinder_update_on_save';
 
-        $resultado = $wpdb->get_var("SELECT * FROM $table_name WHERE post_id = $post_id");
+        $result = $wpdb->get_var("SELECT * FROM $table_name WHERE post_id = $post_id");
 
-        if ($resultado != null) {
+        if ($result != null) {
             $wpdb->update(
                 $table_name,
                 array(
@@ -183,7 +183,7 @@ class Update_On_Save
                     'type_post' => $post_type,
                     'type_action' => $action
                 ),
-                array('id' => $resultado)
+                array( 'post_id' => $result )
             );
         } else {
             $wpdb->insert(

--- a/doofinder-for-woocommerce/includes/class-update-on-save.php
+++ b/doofinder-for-woocommerce/includes/class-update-on-save.php
@@ -183,7 +183,7 @@ class Update_On_Save
                     'type_post' => $post_type,
                     'type_action' => $action
                 ),
-                array( 'post_id' => $result )
+                array( 'post_id' => $post_id )
             );
         } else {
             $wpdb->insert(

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.2.16
+Version: 2.2.17
 Requires at least: 5.6
 Tested up to: 6.3.1
 Requires PHP: 7.0
-Stable tag: 2.2.16
+Stable tag: 2.2.17
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Just send your questions to <mailto:support@doofinder.com> and we will try to an
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.2.17 =
+- Fixed WPDB query in the update on save.
 
 = 2.2.16 =
 - Improved script injection in languages with different suffixes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.16",
+  "version": "2.2.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.2.16",
+      "version": "2.2.17",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.16",
+  "version": "2.2.17",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2305

This PR solves a bug where the WHERE field was being used as id instead of post_id. However it might not be totally related to the bug reported by the customer which claims that his web is down when our plugin is enabled.