### PR TITLE
PLUGINRANGERS-2315 | Added use statement to properly use WP_Http class

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: Doofinder WP & WooCommerce Search
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.2.17
+ * Version: 2.2.18
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -36,7 +36,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          * @var string
          */
 
-        public static $version = '2.2.17';
+        public static $version = '2.2.18';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/class-update-on-save-api.php
+++ b/doofinder-for-woocommerce/includes/api/class-update-on-save-api.php
@@ -7,6 +7,7 @@ use Doofinder\WP\Log;
 
 use Endpoint_Product;
 use Endpoint_Custom;
+use WP_Http;
 
 /**
  * Handles requests to the Management API.

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === Doofinder WP & WooCommerce Search ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.2.17
+Version: 2.2.18
 Requires at least: 5.6
 Tested up to: 6.3.1
 Requires PHP: 7.0
-Stable tag: 2.2.17
+Stable tag: 2.2.18
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Just send your questions to <mailto:support@doofinder.com> and we will try to an
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.2.18 =
+- Fixed fatal error regarding direct WP_Http class.
 
 = 2.2.17 =
 - Fixed WPDB query in the update on save.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.2.17",
+      "version": "2.2.18",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2315

`WP_Http` is failing since it requires a `use` statement or being used as `\WP_Http`