### PR TITLE
PLUGINRANGERS-2314 | Fatal error unsetting string

### DIFF
--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -179,7 +179,9 @@ class Endpoint_Product
         $items = self::custom_product_endpoint(false, $request_params)->data;
 
         array_walk($items, function (&$product) {
-            unset($product['_links']);
+            if ( is_array( $product ) && array_key_exists( '_links', $product ) ) {
+                unset($product['_links']);
+            }
         });
 
         return $items;

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -88,6 +88,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = 2.2.18 =
 - Fixed fatal error regarding direct WP_Http class.
+- Fixed error on the product endpoint when the links are unset
 
 = 2.2.17 =
 - Fixed WPDB query in the update on save.


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2314

Error:

`Uncaught Error: Cannot unset string offsets in /var/www/vhosts/morger.ch/httpdocs/cms2013/wp-content/plugins/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php:183 `