### PR TITLE
fix: Populate sale_price on parent products

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.2.22
+ * Version: 2.2.23
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -36,7 +36,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          * @var string
          */
 
-        public static $version = '2.2.22';
+        public static $version = '2.2.23';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -601,6 +601,20 @@ class Endpoint_Product
                             $products[$key2]["variants"] = array();
                         }
                         $products[$key2]["variants"][] = $products[$key];
+                        
+                        /* 
+                        Woocommerce API provides the parent product with only a single "price"
+                        corresponding to the minimum price of the variants. However, it is set
+                        in the "price" field, without any "sale_price". Hence, here
+                        we find what should be the sale_price and regular_price from the variants
+                        and populate it so the the indexed parent product has both the regular price
+                        and the sale price of the variant that is being represented
+                        */
+                        if (!empty($product["sale_price"]) && $products[$key2]["price"] === $product["sale_price"]) {
+                            $products[$key2]["sale_price"] = $product["sale_price"];
+                            $products[$key2]["price"] = $product["price"];
+                            $products[$key2]["regular_price"] = $product["regular_price"];
+                        }
                         unset($products[$key]);
                     }
                 }

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.2.22
+Version: 2.2.23
 Requires at least: 5.6
 Tested up to: 6.3.1
 Requires PHP: 7.0
-Stable tag: 2.2.22
+Stable tag: 2.2.23
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -123,6 +123,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.2.23 =
+- Populate sale_price on parent variation for the custom product endpoint
 
 = 2.2.22 =
 - Plugin name, description, images and other public resources have been updated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.22",
+  "version": "2.2.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.2.22",
+      "version": "2.2.23",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.22",
+  "version": "2.2.23",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by doofinder/doofinder-wordpress#88.