### PR TITLE
PLUGINRANGERS-285 | Implemented new endpoint to replace the script with the single one

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.2.23
+ * Version: 2.2.24
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -19,6 +19,7 @@ use Doofinder\WP\Multilanguage\Multilanguage;
 use Doofinder\WP\Admin_Notices;
 
 defined('ABSPATH') or die;
+define( 'DOOFINDER_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 
 if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
 
@@ -36,7 +37,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          * @var string
          */
 
-        public static $version = '2.2.23';
+        public static $version = '2.2.24';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -19,7 +19,6 @@ use Doofinder\WP\Multilanguage\Multilanguage;
 use Doofinder\WP\Admin_Notices;
 
 defined('ABSPATH') or die;
-define( 'DOOFINDER_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 
 if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
 

--- a/doofinder-for-woocommerce/includes/api/class-store-api.php
+++ b/doofinder-for-woocommerce/includes/api/class-store-api.php
@@ -9,8 +9,8 @@ use Doofinder\WP\Log;
 use Doofinder\WP\Multilanguage\Multilanguage;
 use Doofinder\WP\Multilanguage\No_Language_Plugin;
 use Doofinder\WP\Settings;
+use Doofinder\WP\Doofinder_For_WordPress;
 use Exception;
-use WP_Application_Passwords;
 use WP_Http;
 
 defined('ABSPATH') or die();
@@ -205,15 +205,17 @@ class Store_Api
         $name = get_bloginfo('name');
         $store_name = !empty($name) ? $name : "Default Store";
 
-        $store_payload = [
+        $store_payload = array(
             "name" =>  $store_name,
             "platform" =>  is_plugin_active('woocommerce/woocommerce.php') ? "woocommerce" : "wordpress",
             "primary_language" => $primary_language,
             "site_url" => get_bloginfo('url'),
             "sector" => Settings::get_sector(),
             "options" => Store_Helpers::get_store_options(),
-            "search_engines" => $this->build_search_engines($api_keys, $primary_language)
-        ];
+            "search_engines" => $this->build_search_engines($api_keys, $primary_language),
+            "plugin_version" => Doofinder_For_WordPress::$version
+        );
+
         return $store_payload;
     }
 

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-single-script.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-single-script.php
@@ -1,0 +1,95 @@
+<?php
+
+use Doofinder\WP\Endpoints;
+use Doofinder\WP\Helpers;
+use Doofinder\WP\Log;
+use Doofinder\WP\Multilanguage\Multilanguage;
+use Doofinder\WP\Settings;
+
+/**
+ * Class Endpoint_Custom
+ *
+ * This class defines a method to update the current script to the single script version.
+ */
+class Endpoint_Single_Script {
+    const CONTEXT  = "doofinder/v1";
+    const ENDPOINT = "/single-script";
+
+    /**
+     * Initialize the custom single script endpoint.
+     *
+     * @return void
+     */
+    public static function initialize() {
+        add_action( 'rest_api_init', function () {
+            register_rest_route( self::CONTEXT, self::ENDPOINT, array(
+                'methods'             => 'GET',
+                'callback'            => array( __CLASS__, 'update_script_to_single_script' ),
+                'permission_callback' => '__return_true',
+            ) );
+        } );
+    }
+
+    /**
+     * Replaces the current Doofinder script with the single one.
+     *
+     * @return string
+     */
+    public static function update_script_to_single_script() {
+        Endpoints::CheckSecureToken();
+        $log           = new Log();
+        $multilanguage = Multilanguage::instance();
+
+        // If there's no Multilanguage plugin active we still need to process 1 language.
+        $languages = $multilanguage->get_formatted_languages();
+
+        if ( ! $languages ) {
+            $languages[''] = '';
+        }
+
+        $scripts = array();
+
+        foreach ( $languages as $language_code => $language_name ) {
+            /*
+            Suffix for options.
+            This should be empty for default language, and language code
+            for any other.
+            */
+            // These ones will be used in the template
+            $language        = ( $language_code === $multilanguage->get_base_locale() ) ? '' : Helpers::get_language_from_locale( $language_code );
+            $installation_id = self::get_installation_id_from_database_script( $language );
+
+            if ( empty( $installation_id ) ) {
+                $log->log( "Single script could not be updated for language: $language because Installation ID could not be determined." );
+                continue;
+            }
+
+            $region = Settings::get_region();
+            
+            ob_start();
+            require DOOFINDER_PLUGIN_PATH . '/views/single-script.php';
+            $single_script = ob_get_clean();
+
+            $scripts[ $language ] = $single_script;
+
+            Settings::set_js_layer( '', $options_suffix );
+        }
+
+        return $scripts;
+    }
+
+    /**
+     * Gets the installation ID from the script stored in the database.
+     *
+     * @return string
+     */
+    private static function get_installation_id_from_database_script( $language ) {
+        $current_script = Settings::get_js_layer( $language );
+        preg_match( "/installationId: '([a-z0-9-]+)'/", $current_script, $matches );
+        if ( empty( $matches[1] ) ) {
+            return '';
+        }
+
+        return $matches[1];
+    }
+}

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-single-script.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-single-script.php
@@ -65,7 +65,11 @@ class Endpoint_Single_Script {
                 continue;
             }
 
-            $region   = Settings::get_region();
+            $region = Settings::get_region();
+            if ( ! empty( $region ) ) {
+                $region .= '-';
+            }
+
             $currency = is_plugin_active('woocommerce/woocommerce.php') ? get_woocommerce_currency() : "EUR";
             
             ob_start();

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-single-script.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-single-script.php
@@ -1,5 +1,6 @@
 <?php
 
+use Doofinder\WP\Doofinder_For_WordPress;
 use Doofinder\WP\Endpoints;
 use Doofinder\WP\Helpers;
 use Doofinder\WP\Log;
@@ -67,7 +68,7 @@ class Endpoint_Single_Script {
             $region = Settings::get_region();
             
             ob_start();
-            require DOOFINDER_PLUGIN_PATH . '/views/single-script.php';
+            require Doofinder_For_WordPress::plugin_path() . '/views/single-script.php';
             $single_script = ob_get_clean();
 
             $scripts[ $language ] = $single_script;

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-single-script.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-single-script.php
@@ -72,7 +72,7 @@ class Endpoint_Single_Script {
 
             $scripts[ $language ] = $single_script;
 
-            Settings::set_js_layer( '', $options_suffix );
+            Settings::set_js_layer( $single_script, $language );
         }
 
         return $scripts;

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-single-script.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-single-script.php
@@ -65,7 +65,8 @@ class Endpoint_Single_Script {
                 continue;
             }
 
-            $region = Settings::get_region();
+            $region   = Settings::get_region();
+            $currency = is_plugin_active('woocommerce/woocommerce.php') ? get_woocommerce_currency() : "EUR";
             
             ob_start();
             require Doofinder_For_WordPress::plugin_path() . '/views/single-script.php';

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-single-script.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-single-script.php
@@ -34,7 +34,7 @@ class Endpoint_Single_Script {
     /**
      * Replaces the current Doofinder script with the single one.
      *
-     * @return string
+     * @return array
      */
     public static function update_script_to_single_script() {
         Endpoints::CheckSecureToken();

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.2.23
+Version: 2.2.24
 Requires at least: 5.6
 Tested up to: 6.3.1
 Requires PHP: 7.0
-Stable tag: 2.2.23
+Stable tag: 2.2.24
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -124,8 +124,11 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= 2.2.24 =
+- Added a new internal feature to implement changes in the Doofinder script.
+
 = 2.2.23 =
-- Populate sale_price on parent variation for the custom product endpoint
+- Populate sale_price on parent variation for the custom product endpoint.
 
 = 2.2.22 =
 - Plugin name, description, images and other public resources have been updated.

--- a/doofinder-for-woocommerce/views/single-script.php
+++ b/doofinder-for-woocommerce/views/single-script.php
@@ -1,5 +1,5 @@
 <?php
-    if ( ! isset( $installation_id ) || ! isset( $region ) || ! isset( $language_code ) || ! isset($currency) ) {
+    if ( ! isset( $installation_id ) || ! isset( $region ) || ! isset( $language_code ) || ! isset( $currency ) ) {
         die();
     }
     $installation_id = htmlspecialchars( $installation_id, ENT_QUOTES, "UTF-8" );

--- a/doofinder-for-woocommerce/views/single-script.php
+++ b/doofinder-for-woocommerce/views/single-script.php
@@ -1,16 +1,18 @@
 <?php
-    if ( !isset( $installation_id ) || !isset( $region ) || !isset( $language_code ) ) {
+    if ( ! isset( $installation_id ) || ! isset( $region ) || ! isset( $language_code ) || ! isset($currency) ) {
         die();
     }
     $installation_id = htmlspecialchars( $installation_id, ENT_QUOTES, "UTF-8" );
     $region          = htmlspecialchars( $region, ENT_QUOTES, "UTF-8" );
     $language_code   = htmlspecialchars( $language_code, ENT_QUOTES, "UTF-8" );
+    $currency        = htmlspecialchars( $currency, ENT_QUOTES, "UTF-8" );
 ?>
 <?php if ( ! empty( $language_code ) ): ?>
 <script>
   (function(w, k) {w[k] = window[k] || function () { (window[k].q = window[k].q || []).push(arguments) }})(window, "doofinderApp")
 
-  doofinderApp("config", "language", "<?php echo $language_code; ?>")
+  doofinderApp("config", "language", "<?php echo $language_code; ?>");
+  doofinderApp("config", "currency", "<?php echo $currency; ?>");
 </script>
 <?php endif; ?>
 <script src="https://<?php echo $region; ?>-config.doofinder.com/2.x/<?php echo $installation_id; ?>.js" async></script>

--- a/doofinder-for-woocommerce/views/single-script.php
+++ b/doofinder-for-woocommerce/views/single-script.php
@@ -15,4 +15,4 @@
   doofinderApp("config", "currency", "<?php echo $currency; ?>");
 </script>
 <?php endif; ?>
-<script src="https://<?php echo $region; ?>-config.doofinder.com/2.x/<?php echo $installation_id; ?>.js" async></script>
+<script src="https://<?php echo $region; ?>config.doofinder.com/2.x/<?php echo $installation_id; ?>.js" async></script>

--- a/doofinder-for-woocommerce/views/single-script.php
+++ b/doofinder-for-woocommerce/views/single-script.php
@@ -1,0 +1,16 @@
+<?php
+    if ( !isset( $installation_id ) || !isset( $region ) || !isset( $language_code ) ) {
+        die();
+    }
+    $installation_id = htmlspecialchars( $installation_id, ENT_QUOTES, "UTF-8" );
+    $region          = htmlspecialchars( $region, ENT_QUOTES, "UTF-8" );
+    $language_code   = htmlspecialchars( $language_code, ENT_QUOTES, "UTF-8" );
+?>
+<?php if ( ! empty( $language_code ) ): ?>
+<script>
+  (function(w, k) {w[k] = window[k] || function () { (window[k].q = window[k].q || []).push(arguments) }})(window, "doofinderApp")
+
+  doofinderApp("config", "language", "<?php echo $language_code; ?>")
+</script>
+<?php endif; ?>
+<script src="https://<?php echo $region; ?>-config.doofinder.com/2.x/<?php echo $installation_id; ?>.js" async></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.23",
+  "version": "2.2.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.2.23",
+      "version": "2.2.24",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.2.23",
+  "version": "2.2.24",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/doofinder-woocommerce/issues/285

The GIF proves that the request requires a security header to be called and that the old script gets replaced by the new one automatically. However, it must be tested also with WPML enabled.

![doofinder-single-script-update-in-wordpress](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/ee6ed195-a7ce-417d-ae99-fab796d84858)

Multilanguage example:

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/ba32bfe0-53e4-4fda-acc9-f90a8f189917)
