### PR TITLE
PLUGINRANGERS-2522 | Added array check before attribute length retrieval

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.4.1
+ * Version: 2.4.2
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -35,7 +35,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          * @var string
          */
 
-        public static $version = '2.4.1';
+        public static $version = '2.4.2';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -763,10 +763,12 @@ class Endpoint_Product
                     $custom_attributes[$attribute_slug][] = $option;
                 }
                 
-                if ( 0 === count( $custom_attributes[ $attribute_slug ] ) ) {
-                    $custom_attributes[ $attribute_slug ] = '';
-                } elseif ( 1 === count( $custom_attributes[ $attribute_slug ] ) ) {
-                    $custom_attributes[ $attribute_slug ] = $custom_attributes[ $attribute_slug ][0];
+                if ( is_array( $custom_attributes[ $attribute_slug ] ) ) {
+                    if ( 0 === count( $custom_attributes[ $attribute_slug ] ) ) {
+                        $custom_attributes[ $attribute_slug ] = '';
+                    } elseif ( 1 === count( $custom_attributes[ $attribute_slug ] ) ) {
+                        $custom_attributes[ $attribute_slug ] = $custom_attributes[ $attribute_slug ][0];
+                    }
                 }
             }
         }

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.4.1
+Version: 2.4.2
 Requires at least: 5.6
 Tested up to: 6.3.1
 Requires PHP: 7.0
-Stable tag: 2.4.1
+Stable tag: 2.4.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.4.2 =
+- Bugfix, added array checking on attributes data.
 
 = 2.4.1 =
 - Attributes are now returned as strings instead of being arrays.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2522


It should fix a bug related to https://github.com/doofinder/doofinder-woocommerce/pull/299 where we were assuming that the inner data will be always an array (it could be null too)

Proof that works:

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/c09ece2b-2e6c-4f43-ab38-083494d28080)
