### PR TITLE
PLUGINRANGERS-2522 | Added empty check before is array to prevent errors on PHP >= 8.0

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.4.2
+ * Version: 2.4.3
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -35,7 +35,7 @@ if (!class_exists('\Doofinder\WP\Doofinder_For_WordPress')) :
          * @var string
          */
 
-        public static $version = '2.4.2';
+        public static $version = '2.4.3';
 
         /**
          * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -763,12 +763,10 @@ class Endpoint_Product
                     $custom_attributes[$attribute_slug][] = $option;
                 }
                 
-                if ( ! empty( $custom_attributes[ $attribute_slug ] ) && is_array( $custom_attributes[ $attribute_slug ] ) ) {
-                    if ( 0 === count( $custom_attributes[ $attribute_slug ] ) ) {
-                        $custom_attributes[ $attribute_slug ] = '';
-                    } elseif ( 1 === count( $custom_attributes[ $attribute_slug ] ) ) {
-                        $custom_attributes[ $attribute_slug ] = $custom_attributes[ $attribute_slug ][0];
-                    }
+                if ( ! empty( $custom_attributes[ $attribute_slug ] ) && 
+                    is_array( $custom_attributes[ $attribute_slug ] ) &&  
+                    1 === count( $custom_attributes[ $attribute_slug ] ) ) {
+                    $custom_attributes[ $attribute_slug ] = $custom_attributes[ $attribute_slug ][0];
                 }
             }
         }

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -763,7 +763,7 @@ class Endpoint_Product
                     $custom_attributes[$attribute_slug][] = $option;
                 }
                 
-                if ( is_array( $custom_attributes[ $attribute_slug ] ) ) {
+                if ( ! empty( $custom_attributes[ $attribute_slug ] ) && is_array( $custom_attributes[ $attribute_slug ] ) ) {
                     if ( 0 === count( $custom_attributes[ $attribute_slug ] ) ) {
                         $custom_attributes[ $attribute_slug ] = '';
                     } elseif ( 1 === count( $custom_attributes[ $attribute_slug ] ) ) {

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.4.2
+Version: 2.4.3
 Requires at least: 5.6
 Tested up to: 6.3.1
 Requires PHP: 7.0
-Stable tag: 2.4.2
+Stable tag: 2.4.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.4.3 =
+- Bugfix, added array checking on attributes data for PHP >= 8.0.
 
 = 2.4.2 =
 - Bugfix, added array checking on attributes data.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2522

Fixes PHP >= 8.0 for: https://github.com/doofinder/doofinder-woocommerce/pull/300

While the last fix was valid for PHP <= 7.4, is not valid for PHP >= 8.0 because is_array is not enough to prevent errors while accesing keys that are not present in the array, so `! empty() `or `array_key_exists()` must be used before.

Proof

PHP 7.4:

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/174b2330-3d82-4ca3-9354-b1bfea125c1d)


Works with a warning

PHP 8.0

Does not work at all:

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/5c97c4c0-6e7e-4059-aa79-d37213c68306)

With ! empty() checking:

![image](https://github.com/doofinder/doofinder-woocommerce/assets/128705267/cb595354-469e-415d-8873-d9fd97e6a8fd)
