### PR TITLE
Fix cron schedules order issues

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -449,5 +449,5 @@ register_deactivation_hook( __FILE__, array( '\Doofinder\WP\Doofinder_For_WordPr
 add_action( 'admin_enqueue_scripts', array( '\Doofinder\WP\Doofinder_For_WordPress', 'load_only_doofinder_admin_scripts_and_styles' ), 10, 2 );
 add_action( 'plugins_loaded', array( '\Doofinder\WP\Doofinder_For_WordPress', 'instance' ), 0 );
 add_action( 'upgrader_process_complete', array( '\Doofinder\WP\Doofinder_For_WordPress', 'upgrader_process_complete' ), 10, 2 );
-// Add cron_schedules here to avoid issues with hook order
+// Add cron_schedules here to avoid issues with hook order.
 add_filter( 'cron_schedules', array( '\Doofinder\WP\Settings', 'add_schedules' ), 100, 1 ); // phpcs:ignore WordPress.WP.CronInterval

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -449,5 +449,5 @@ register_deactivation_hook( __FILE__, array( '\Doofinder\WP\Doofinder_For_WordPr
 add_action( 'admin_enqueue_scripts', array( '\Doofinder\WP\Doofinder_For_WordPress', 'load_only_doofinder_admin_scripts_and_styles' ), 10, 2 );
 add_action( 'plugins_loaded', array( '\Doofinder\WP\Doofinder_For_WordPress', 'instance' ), 0 );
 add_action( 'upgrader_process_complete', array( '\Doofinder\WP\Doofinder_For_WordPress', 'upgrader_process_complete' ), 10, 2 );
-//Add cron_schedules here to avoid issues with hook order
+// Add cron_schedules here to avoid issues with hook order
 add_filter( 'cron_schedules', array( '\Doofinder\WP\Settings', 'add_schedules' ), 100, 1 ); // phpcs:ignore WordPress.WP.CronInterval

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.5.1
+ * Version: 2.5.2
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -37,7 +37,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.5.1';
+		public static $version = '2.5.2';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress
@@ -449,3 +449,5 @@ register_deactivation_hook( __FILE__, array( '\Doofinder\WP\Doofinder_For_WordPr
 add_action( 'admin_enqueue_scripts', array( '\Doofinder\WP\Doofinder_For_WordPress', 'load_only_doofinder_admin_scripts_and_styles' ), 10, 2 );
 add_action( 'plugins_loaded', array( '\Doofinder\WP\Doofinder_For_WordPress', 'instance' ), 0 );
 add_action( 'upgrader_process_complete', array( '\Doofinder\WP\Doofinder_For_WordPress', 'upgrader_process_complete' ), 10, 2 );
+//Add cron_schedules here to avoid issues with hook order
+add_filter( 'cron_schedules', array( '\Doofinder\WP\Settings', 'add_schedules' ), 100, 1 ); // phpcs:ignore WordPress.WP.CronInterval

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -121,7 +121,7 @@ class Endpoint_Product {
 
 			foreach ( $products as $product_data ) {
 				// If the product is not a valid WC product, ignore it.
-				if ( false === wc_get_product( $product_data['id'] ) ) {
+				if ( ! isset( $product_data['id'] ) || empty( $product_data['id'] ) || false === wc_get_product( $product_data['id'] ) ) {
 					continue;
 				}
 
@@ -673,7 +673,7 @@ class Endpoint_Product {
 				unset( $product['type'] );
 			}
 
-			$attributes = $product['attributes'];
+			$attributes = isset( $product['attributes'] ) && is_array( $product['attributes'] ) ? $product['attributes'] : array();
 
 			if ( 'variable' === $type ) {
 				$variations_data = self::process_variations( $product );

--- a/doofinder-for-woocommerce/includes/class-settings.php
+++ b/doofinder-for-woocommerce/includes/class-settings.php
@@ -173,8 +173,6 @@ class Settings {
 			10,
 			3
 		);
-
-		add_filter( 'cron_schedules', array( __CLASS__, 'add_schedules' ), 100, 1 ); // phpcs:ignore WordPress.WP.CronInterval
 	}
 	/**
 	 * Returns an array with select options structured by option groups

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Required by
- https://github.com/doofinder/support/issues/2588

## Changelog
- Moved cron_schedules add_filter to the main plugin file.
- Fixed some errors that occurred when accessing invalid woocommerce product properties.