### PR TITLE
Fix update on save cron bug

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -509,11 +509,16 @@ add_action( 'upgrader_process_complete', array( '\Doofinder\WP\Doofinder_For_Wor
 // Add cron_schedules here to avoid issues with hook order.
 add_filter( 'cron_schedules', array( '\Doofinder\WP\Doofinder_For_WordPress', 'add_schedules' ), 100, 1 ); // phpcs:ignore WordPress.WP.CronInterval
 
-// When doing update on save from cron we are not authenticated, so WP_REST_Request to get products data returned a 401
-add_filter('woocommerce_rest_check_permissions', function ( $permission, $context, $object_id, $post_type ) {
-	if(wp_doing_cron() && $context === 'read' && doing_action('doofinder_update_on_save')) {
-		return true;
-	}
+// When doing update on save from cron we are not authenticated, so WP_REST_Request to get products data returned a 401.
+add_filter(
+	'woocommerce_rest_check_permissions',
+	function ( $permission, $context ) {
+		if ( wp_doing_cron() && 'read' === $context && doing_action( 'doofinder_update_on_save' ) ) {
+			return true;
+		}
 
-	return $permission;
-}, 100, 4);
+		return $permission;
+	},
+	100,
+	4
+);

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.5.6
+ * Version: 2.5.7
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -38,7 +38,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.5.6';
+		public static $version = '2.5.7';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress
@@ -508,3 +508,12 @@ add_action( 'plugins_loaded', array( '\Doofinder\WP\Doofinder_For_WordPress', 'i
 add_action( 'upgrader_process_complete', array( '\Doofinder\WP\Doofinder_For_WordPress', 'upgrader_process_complete' ), 10, 2 );
 // Add cron_schedules here to avoid issues with hook order.
 add_filter( 'cron_schedules', array( '\Doofinder\WP\Doofinder_For_WordPress', 'add_schedules' ), 100, 1 ); // phpcs:ignore WordPress.WP.CronInterval
+
+// When doing update on save from cron we are not authenticated, so WP_REST_Request to get products data returned a 401
+add_filter('woocommerce_rest_check_permissions', function ( $permission, $context, $object_id, $post_type ) {
+	if(wp_doing_cron() && $context === 'read' && doing_action('doofinder_update_on_save')) {
+		return true;
+	}
+
+	return $permission;
+}, 100, 4);

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -520,5 +520,5 @@ add_filter(
 		return $permission;
 	},
 	100,
-	4
+	2
 );

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.5.6
+Version: 2.5.7
 Requires at least: 5.6
 Tested up to: 6.6.1
 Requires PHP: 7.0
-Stable tag: 2.5.6
+Stable tag: 2.5.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.5.7 =
+- Fixed update on save cron not working as expected.
 
 = 2.5.6 =
 - Fixed attribute not exported when they are empty values. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We have a bug in the update on save functionality when it is launched from the cron (https://github.com/doofinder/doofinder-woocommerce/issues/328).

The cron execution context does not have a user set, so the requests to the wordpress internal API fail. In this PR we modify the `woocommerce_rest_check_permissions` filter so that it allows requests to pass only in this case.

Thanks to @eugeniobonifacio for the suggestion of the fix!