### PR TITLE
Remove sale_price from response if it is empty

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.5.7
+ * Version: 2.5.8
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -38,7 +38,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.5.7';
+		public static $version = '2.5.8';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -436,8 +436,8 @@ class Endpoint_Product {
 		$product['price']         = '' === (string) $regular_price ? $price : $regular_price;
 		$final_sale_price         = '' === (string) $sale_price || $price < $regular_price ? $price : $sale_price;
 
-		if (empty($final_sale_price)) {
-			unset($product['sale_price']);
+		if ( empty( $final_sale_price ) ) {
+			unset( $product['sale_price'] );
 		} else {
 			$product['sale_price'] = $final_sale_price;
 		}

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -434,7 +434,13 @@ class Endpoint_Product {
 
 		$product['regular_price'] = $regular_price;
 		$product['price']         = '' === (string) $regular_price ? $price : $regular_price;
-		$product['sale_price']    = '' === (string) $sale_price && $price < $regular_price ? $price : $sale_price;
+		$final_sale_price         = '' === (string) $sale_price || $price < $regular_price ? $price : $sale_price;
+
+		if (empty($final_sale_price)) {
+			unset($product['sale_price']);
+		} else {
+			$product['sale_price'] = $final_sale_price;
+		}
 
 		return $product;
 	}

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.5.7
+Version: 2.5.8
 Requires at least: 5.6
 Tested up to: 6.6.1
 Requires PHP: 7.0
-Stable tag: 2.5.7
+Stable tag: 2.5.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.5.8 =
+- Fixed issue with sale_price field during indexation.
 
 = 2.5.7 =
 - Fixed update on save cron not working as expected.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by https://github.com/doofinder/support/issues/2800

Con el cambio introducido en este [commit](https://github.com/doofinder/doofinder-woocommerce/commit/5d3dfa94fa8f1e7225a238b722c265070fe70139#diff-2165d17b8be746fcfa129c9a62c441135a710c4a20bf13569166be566e7ee323R581) se cambia empty por is_null, eso ha provocado que sale_price no se eliminara de la respuesta si era empty. Al menos en un cliente a provocado que en la capa los productos sin descuentos si muestren con descuento del 100%, también afectaba otros campos que dependían del valor de sale_price.