### PR TITLE
PLUGINRAGERS-329 | Custom attributes are used in df_variants_information now

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Subversion
         run: sudo apt-get install subversion
       - name: Build

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.5.13
+ * Version: 2.5.14
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -38,7 +38,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.5.13';
+		public static $version = '2.5.14';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -764,13 +764,51 @@ class Endpoint_Product {
 			}
 		);
 
+		$custom_attributes_mapping = Settings::get_custom_attributes();
+		$custom_attr_fields        = self::get_field_attributes( $custom_attributes_mapping );
+
 		$variation_attributes = array();
 		foreach ( $attributes as $p_attr ) {
 			if ( $p_attr['variation'] && in_array( strtolower( $p_attr['name'] ), $product_attributes, true ) ) {
-				$variation_attributes[] = strtolower( $p_attr['name'] );
+				$variation_attributes[] = self::get_real_product_attribute_name( $p_attr, $custom_attr_fields );
 			}
 		}
 		return $variation_attributes;
+	}
+
+	/**
+	 * Retrieves the mapped custom name for a WooCommerce product attribute.
+	 *
+	 * This function checks if a WooCommerce product attribute ID is mapped to a custom name
+	 * specified in the Data Configuration tab. If a custom name is found, it returns that name.
+	 * Otherwise, it returns the lowercase version of the original attribute name. Due to the
+	 * structure of the custom attributes mapping, it is necessary to flip the keys and the
+	 * values to achieve the described purpose.
+	 *
+	 * Example of custom attributes mapping structure:
+	 *
+	 * array(
+	 *    "size_custom"  => "wc_2",
+	 *    "color_custom" => "wc_1",
+	 *    [...]
+	 * );
+	 *
+	 * @param array $product_attribute An associative array representing the product attribute, containing:
+	 *                                 - 'id'   (int): The WooCommerce attribute ID.
+	 *                                 - 'name' (string): The default attribute name.
+	 * @param array $custom_attr_fields An associative array of custom attribute fields, where each custom name maps
+	 *                                  to a WooCommerce attribute key (e.g., 'wc_{id}').
+	 *
+	 * @return string The custom attribute name if found; otherwise, the original attribute name in lowercase.
+	 */
+	private static function get_real_product_attribute_name( $product_attribute, $custom_attr_fields ) {
+		$wc_id                      = 'wc_' . $product_attribute['id'];
+		$custom_attr_fields_mapping = array_flip( $custom_attr_fields );
+		if ( array_key_exists( $wc_id, $custom_attr_fields_mapping ) ) {
+			return $custom_attr_fields_mapping[ $wc_id ];
+		}
+
+		return strtolower( $product_attribute['name'] );
 	}
 
 	/**

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.5.13
+Version: 2.5.14
 Requires at least: 5.6
 Tested up to: 6.6.1
 Requires PHP: 7.0
-Stable tag: 2.5.13
+Stable tag: 2.5.14
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.5.14 =
+- Fixed an issue with the df_variants_information that were not using the custom naming from the settings.
 
 = 2.5.13 =
 - Fixed an issue with the nonce verification in the store wizard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.5.13",
+  "version": "2.5.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.5.13",
+      "version": "2.5.14",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.5.13",
+  "version": "2.5.14",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/doofinder-woocommerce/issues/329

Proof that works:

WP Admin:

![image](https://github.com/user-attachments/assets/b349021c-8cb5-4a74-a5b9-2e5d068953df)

Doomanager:

![image](https://github.com/user-attachments/assets/6745cdd9-c0a8-4b4a-962c-352f33acb9e7)
