### PR TITLE
PLUGINRANGERS-339 | Fixed typo in previous description text

### DIFF
--- a/doofinder-for-woocommerce/includes/settings/class-register-settings.php
+++ b/doofinder-for-woocommerce/includes/settings/class-register-settings.php
@@ -222,7 +222,7 @@ trait Register_Settings {
 				<p class="description">
 					<?php
 					esc_html_e(
-						'The following options allow you to set up which data would you like to index',
+						'The following options allow you to set up which data you would like to index.',
 						'wordpress-doofinder'
 					);
 					?>
@@ -272,7 +272,7 @@ trait Register_Settings {
 				<p>
 					<?php
 					esc_html_e(
-						'The following options allow you to set up which data would you like to index.',
+						'The following options allow you to set up which data you would like to index.',
 						'wordpress-doofinder'
 					);
 					?>


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/doofinder-woocommerce/issues/329

Version bump is not needed since it will be included with another previously merged PR which has already increased the version.