### PR TITLE
PLUGINRANGERS-3038 | Prevent false prices + actual bugfix of normalization

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.5.18
+ * Version: 2.5.19
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -40,7 +40,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.5.18';
+		public static $version = '2.5.19';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/class-store-api.php
+++ b/doofinder-for-woocommerce/includes/api/class-store-api.php
@@ -133,20 +133,21 @@ class Store_Api {
 		);
 
 		foreach ( $store_payload['search_engines'] as $search_engine ) {
-			$lang_country = Helpers::format_locale_to_underscore( $search_engine['language'] );
-			$lang         = Helpers::get_language_from_locale( $search_engine['language'] );
-			$base_lang    = Helpers::get_language_from_locale( $this->language->get_base_language() );
+			// $lang_real will remain unchanged unlike $lang that can be changed to ''.
+			$lang      = Helpers::get_language_from_locale( $search_engine['language'] );
+			$lang_real = $lang;
+			$base_lang = Helpers::get_language_from_locale( $this->language->get_base_language() );
 
 			// If the installation is not multilanguage or it's the base language, replace the lang with ''.
 			if ( is_a( $this->language, No_Language_Plugin::class ) || $lang === $base_lang ) {
-				$lang_country = '';
+				$lang = '';
 			}
 
-			if ( isset( $api_keys[ $lang_country ] ) ) {
-				$se_hashid                               = $api_keys[ $lang_country ]['hash'];
-				$payload['search_engines'][ $se_hashid ] = array( 'lang' => $lang );
+			if ( isset( $api_keys[ $lang ] ) ) {
+				$se_hashid                               = $api_keys[ $lang ]['hash'];
+				$payload['search_engines'][ $se_hashid ] = array( 'lang' => $lang_real );
 			} else {
-				$this->log->log( 'No search engine retrieved for the language - ' . $lang );
+				$this->log->log( 'No search engine retrieved for the language - ' . $lang_real );
 			}
 		}
 

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -467,7 +467,7 @@ class Endpoint_Product {
 		// If sale price is empty, do not attempt to get the raw real price, as we will get the original price.
 		$raw_price = 'sale_price' === $price_name && '' === $price ? '' : self::get_raw_real_price( $price, $wc_product );
 		// If price is equal to 0, return an empty string.
-		$raw_price = ( 0 === $raw_price ) ? '' : $raw_price;
+		$raw_price = ( false === $raw_price || 0 === $raw_price ) ? '' : $raw_price;
 		return $raw_price;
 	}
 

--- a/doofinder-for-woocommerce/includes/class-setup-wizard.php
+++ b/doofinder-for-woocommerce/includes/class-setup-wizard.php
@@ -1359,7 +1359,7 @@ class Setup_Wizard {
 			$api_keys_array = array();
 
 			foreach ( $language->get_languages() as $lang ) {
-				$code = $lang['locale'] === $language->get_base_locale() ? '' : $lang['locale'];
+				$code = $lang['locale'] === $language->get_base_locale() ? '' : Helpers::get_language_from_locale( $lang['locale'] );
 				$hash = Settings::get_search_engine_hash( $code );
 				$hash = ! $hash ? 'no-hash' : $hash;
 

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.5.18
+Version: 2.5.19
 Requires at least: 5.6
 Tested up to: 6.7.1
 Requires PHP: 7.0
-Stable tag: 2.5.18
+Stable tag: 2.5.19
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,10 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.5.19 =
+- Prevented errors if the prices come as false instead of 0.
+- Actually solved an issue regarding indices normalization on multilanguages.
 
 = 2.5.18 =
 - Added custom Doofinder logo to the sidebar menu item.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.5.18",
+  "version": "2.5.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.5.18",
+      "version": "2.5.19",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.5.18",
+  "version": "2.5.19",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/3038

Actually fixes:

- https://github.com/doofinder/support/issues/3053

This PR prevents prices to be returned as false, so instead, they will be treated as 0, so '' will be returned instead (tested directly on the customer's WP and works):

![image](https://github.com/user-attachments/assets/52516085-6e9e-4477-9c9a-ea6141901974)

Apart from this, I have noticed that the fix applied on https://github.com/doofinder/support/issues/3053 was not working as expected, since now the original SE was being retrieved as "no-hash". Now every SE have their hashids correctly assigned:

```json
{
   "store_options":{
      "url":"http:\\/\\/david-wordpress.ngrok.doofinder.com",
      "api_pass":"************************",
      "api_user":"*****",
      "df_token":"************************"
   },
   "platform":"woocommerce",
   "search_engines":{
      "98ed13ef9bb6627cf9cb953437a7a8ce":{
         "lang":"en"
      },
      "331bef2efc54c931693b57cc0075f1dc":{
         "lang":"es"
      }
   }
}
```