### PR TITLE
Bugfix Update on save dont update custom attributes

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.6.1
+ * Version: 2.6.2
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -40,7 +40,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.6.1';
+		public static $version = '2.6.2';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -103,10 +103,10 @@ class Endpoint_Product {
 			);
 		} else {
 			// Update on save.
-			$fields_param 				= $config_request['fields'] ?? '';
-			$fields       				= ! empty( $fields_param ) ? explode( ',', $fields_param ) : array();
-			$fields       				= array_merge( $fields, array_values( $custom_attr_fields ) );
-			$config_request['fields'] 	= $fields;
+			$fields_param             = $config_request['fields'] ?? '';
+			$fields                   = ! empty( $fields_param ) ? explode( ',', $fields_param ) : array();
+			$fields                   = array_merge( $fields, array_values( $custom_attr_fields ) );
+			$config_request['fields'] = $fields;
 		}
 
 		// Retrieve the original product data.

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -103,10 +103,10 @@ class Endpoint_Product {
 			);
 		} else {
 			// Update on save.
-			$fields_param = $config_request['fields'] ?? '';
-			$fields       = ! empty( $fields_param ) ? explode( ',', $fields_param ) : array();
-			$fields       = array_merge( $fields, array_values( $custom_attr_fields ) );
-			$config_request["fields"] = $fields;
+			$fields_param 				= $config_request['fields'] ?? '';
+			$fields       				= ! empty( $fields_param ) ? explode( ',', $fields_param ) : array();
+			$fields       				= array_merge( $fields, array_values( $custom_attr_fields ) );
+			$config_request['fields'] 	= $fields;
 		}
 
 		// Retrieve the original product data.

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -106,6 +106,7 @@ class Endpoint_Product {
 			$fields_param = $config_request['fields'] ?? '';
 			$fields       = ! empty( $fields_param ) ? explode( ',', $fields_param ) : array();
 			$fields       = array_merge( $fields, array_values( $custom_attr_fields ) );
+			$config_request["fields"] = $fields;
 		}
 
 		// Retrieve the original product data.

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.6.1
+Version: 2.6.2
 Requires at least: 5.6
 Tested up to: 6.7.1
 Requires PHP: 7.0
-Stable tag: 2.6.1
+Stable tag: 2.6.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.6.2 =
+- Bugfix update on save dont update custom attributes
 
 = 2.6.1 =
 - Added region validation.

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -127,7 +127,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 == Changelog ==
 
 = 2.6.2 =
-- Bugfix update on save dont update custom attributes
+- Bugfix update on save doesn't update custom attributes
 
 = 2.6.1 =
 - Added region validation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by: https://github.com/doofinder/support/issues/3269

Basically, the fields were updated with those of the custom attributes, but when a request was made, the fields of the request that were not being updated were used.