### PR TITLE
PLUGINRANGERS-3442 | Prevented error when creating stores via Store Wizard if no multilang plugin is active

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.7.3
+ * Version: 2.7.4
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -40,7 +40,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.7.3';
+		public static $version = '2.7.4';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/class-setup-wizard.php
+++ b/doofinder-for-woocommerce/includes/class-setup-wizard.php
@@ -1115,20 +1115,33 @@ class Setup_Wizard {
 		}
 
 		// Api Host should contain 'https://' protocol, i.e. https://eu1-admin.doofinder.com.
-		if ( ! preg_match( '#^((https?://)|www\.?)#i', $api_host ) ) {
-			$api_host = 'https://' . $api_host;
-		}
-
+		$api_host = self::maybe_prepend_https_schema( $api_host );
 		// Dooplugins Host should contain 'https://' protocol, i.e. https://eu1-plugins.doofinder.com.
-		if ( ! preg_match( '#^((https?://)|www\.?)#i', $dooplugins_host ) ) {
-			$dooplugins_host = 'https://' . $dooplugins_host;
-		}
+		$dooplugins_host = self::maybe_prepend_https_schema( $dooplugins_host );
 
 		return array(
 			'api_key'         => $api_key,
 			'api_host'        => $api_host,
 			'dooplugins_host' => $dooplugins_host,
 		);
+	}
+
+	/**
+	 * Ensures a URL has an HTTPS schema if missing.
+	 *
+	 * This function checks if a URL already contains "http://", "https://", or starts with "www.".
+	 * If not, it prepends "https://" to ensure a valid URL format.
+	 *
+	 * @param string $url The URL to check and modify if necessary.
+	 *
+	 * @return string The URL with "https://" prepended if needed.
+	 */
+	private static function maybe_prepend_https_schema( $url ) {
+		if ( preg_match( '#^((https?://)|www\.?)#i', $url ) ) {
+			return $url;
+		}
+
+		return 'https://' . $url;
 	}
 
 	/**

--- a/doofinder-for-woocommerce/includes/class-setup-wizard.php
+++ b/doofinder-for-woocommerce/includes/class-setup-wizard.php
@@ -1054,15 +1054,18 @@ class Setup_Wizard {
 		$languages = $this->language->get_formatted_languages();
 
 		if ( ! $languages ) {
+			$languages     = array();
 			$languages[''] = '';
 		}
 
 		// Clear per language settings.
 
 		foreach ( $languages as $language_code => $language_data ) {
+			// If no multillang is present, the code will be ''.
+			$locale = ! empty( $language_data['code'] ) ? $language_data['code'] : '';
 			// Suffix for options.
 			// This should be empty for default language, and language code for any other.
-			$options_suffix = ( $language_code === $this->language->get_base_locale() ) ? '' : $language_data['code'];
+			$options_suffix = ( $language_code === $this->language->get_base_locale() ) ? '' : $locale;
 
 			// Search engine data.
 			Settings::set_search_engine_hash( '', $options_suffix );
@@ -1114,6 +1117,11 @@ class Setup_Wizard {
 		// Api Host should contain 'https://' protocol, i.e. https://eu1-admin.doofinder.com.
 		if ( ! preg_match( '#^((https?://)|www\.?)#i', $api_host ) ) {
 			$api_host = 'https://' . $api_host;
+		}
+
+		// Dooplugins Host should contain 'https://' protocol, i.e. https://eu1-plugins.doofinder.com.
+		if ( ! preg_match( '#^((https?://)|www\.?)#i', $dooplugins_host ) ) {
+			$dooplugins_host = 'https://' . $dooplugins_host;
 		}
 
 		return array(
@@ -1373,11 +1381,7 @@ class Setup_Wizard {
 		} else {
 			$hash = Settings::get_search_engine_hash();
 
-			if ( $hash ) {
-				return true;
-			} else {
-				return false;
-			}
+			return (bool) $hash;
 		}
 	}
 }

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.7.3
+Version: 2.7.4
 Requires at least: 5.6
 Tested up to: 6.7.1
 Requires PHP: 7.0
-Stable tag: 2.7.3
+Stable tag: 2.7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.7.4 =
+- Bugfix in Store Wizard if no multiplang plugin is present.
 
 = 2.7.3 =
 - Improve Search Engine creation for languages with the same ISO code, but different country (e.g. pt-PT and pt-BR).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.7.3",
+      "version": "2.7.4",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/3442

Basically, if no multilang plugin (WPML) is active, the $language value was `''`, so $language['code'] cannot be retrieved.