### PR TITLE
Add parent category paths in the `category_merchandising` field.

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.7.7
+ * Version: 2.7.8
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -40,7 +40,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.7.7';
+		public static $version = '2.7.8';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-custom.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-custom.php
@@ -187,6 +187,8 @@ class Endpoint_Custom {
 	 * @return array The filtered data array with post tags information if requested.
 	 */
 	private static function get_post_tags( $filtered_data, $fields ) {
+		$filtered_data['post_tags'] = [];
+
 		if ( in_array( 'post_tags', $fields, true ) && isset( $filtered_data['_embedded']['wp:term'][0] ) ) {
 			$filtered_data['post_tags'] = self::get_terms( 'post_tag', $filtered_data['_embedded']['wp:term'] );
 		}
@@ -203,6 +205,8 @@ class Endpoint_Custom {
 	 * @return array The filtered data array with categories information if requested.
 	 */
 	private static function get_categories( $filtered_data, $fields ) {
+		$filtered_data['categories'] = [];
+		
 		if ( in_array( 'categories', $fields, true ) && isset( $filtered_data['_embedded']['wp:term'][0] ) ) {
 			$filtered_data['categories'] = self::get_terms( 'category', $filtered_data['_embedded']['wp:term'] );
 		}

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-custom.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-custom.php
@@ -187,7 +187,7 @@ class Endpoint_Custom {
 	 * @return array The filtered data array with post tags information if requested.
 	 */
 	private static function get_post_tags( $filtered_data, $fields ) {
-		$filtered_data['post_tags'] = [];
+		$filtered_data['post_tags'] = array();
 
 		if ( in_array( 'post_tags', $fields, true ) && isset( $filtered_data['_embedded']['wp:term'][0] ) ) {
 			$filtered_data['post_tags'] = self::get_terms( 'post_tag', $filtered_data['_embedded']['wp:term'] );
@@ -205,8 +205,8 @@ class Endpoint_Custom {
 	 * @return array The filtered data array with categories information if requested.
 	 */
 	private static function get_categories( $filtered_data, $fields ) {
-		$filtered_data['categories'] = [];
-		
+		$filtered_data['categories'] = array();
+
 		if ( in_array( 'categories', $fields, true ) && isset( $filtered_data['_embedded']['wp:term'][0] ) ) {
 			$filtered_data['categories'] = self::get_terms( 'category', $filtered_data['_embedded']['wp:term'] );
 		}

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -254,7 +254,7 @@ class Endpoint_Product {
 	 * @return array The processed data.
 	 */
 	private static function get_categories( $data ) {
-		$data['categories'] = [];
+		$data['categories'] = array();
 		if ( isset( $data['categories'] ) ) {
 			$data['categories'] = self::get_category_path( $data['categories'] );
 		}
@@ -271,39 +271,39 @@ class Endpoint_Product {
 	 * @since 2.7.6
 	 */
 	private static function get_category_merchandising( $data ) {
-		$data['category_merchandising'] = [];
-	
+		$data['category_merchandising'] = array();
+
 		if ( isset( $data['categories'] ) ) {
 			foreach ( $data['categories'] as $category ) {
 				if ( empty( $category['id'] ) || ! is_numeric( $category['id'] ) ) {
 					continue;
 				}
-	
+
 				$term = get_term( (int) $category['id'], self::TAXONOMY );
 				if ( ! $term || is_wp_error( $term ) ) {
 					continue;
 				}
 
 				// Obtain the hierarchy from root to the current category
-				$ancestors = get_ancestors( $term->term_id, self::TAXONOMY );
-				$ancestors = array_reverse( $ancestors ); // Start from root
+				$ancestors     = get_ancestors( $term->term_id, self::TAXONOMY );
+				$ancestors     = array_reverse( $ancestors ); // Start from root
 				$full_path_ids = array_merge( $ancestors, array( $term->term_id ) );
-	
+
 				foreach ( $full_path_ids as $term_id ) {
 					$term_link = get_term_link( (int) $term_id, self::TAXONOMY );
 					if ( is_wp_error( $term_link ) ) {
 						continue;
 					}
-	
+
 					$components    = wp_parse_url( $term_link );
 					$relative_link = isset( $components['path'] ) ? $components['path'] : '';
-	
+
 					if ( ! empty( $components['query'] ) ) {
 						$relative_link .= '?' . $components['query'];
 					}
-	
+
 					$relative_link = trim( $relative_link, '/' );
-					
+
 					// Avoid duplicates
 					if ( ! in_array( $relative_link, $data['category_merchandising'], true ) ) {
 						$data['category_merchandising'][] = $relative_link;
@@ -311,10 +311,10 @@ class Endpoint_Product {
 				}
 			}
 		}
-	
+
 		return $data;
 	}
-	
+
 	/**
 	 * Merge custom attributes into the data.
 	 *

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -284,9 +284,9 @@ class Endpoint_Product {
 					continue;
 				}
 
-				// Obtain the hierarchy from root to the current category
+				// Obtain the hierarchy from root to the current category.
 				$ancestors     = get_ancestors( $term->term_id, self::TAXONOMY );
-				$ancestors     = array_reverse( $ancestors ); // Start from root
+				$ancestors     = array_reverse( $ancestors ); // Start from root.
 				$full_path_ids = array_merge( $ancestors, array( $term->term_id ) );
 
 				foreach ( $full_path_ids as $term_id ) {
@@ -304,7 +304,7 @@ class Endpoint_Product {
 
 					$relative_link = trim( $relative_link, '/' );
 
-					// Avoid duplicates
+					// Avoid duplicates.
 					if ( ! in_array( $relative_link, $data['category_merchandising'], true ) ) {
 						$data['category_merchandising'][] = $relative_link;
 					}

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -52,7 +52,7 @@ class Endpoint_Product {
 		'type',
 	);
 
-	const TAXONOMY = self::TAXONOMY;
+	const TAXONOMY = 'product_cat';
 
 	/**
 	 * Initialize the custom product endpoint.

--- a/doofinder-for-woocommerce/includes/polyfills.php
+++ b/doofinder-for-woocommerce/includes/polyfills.php
@@ -45,24 +45,26 @@ if ( ! function_exists( 'str_ends_with' ) ) {
 		return 0 === strlen( $needle ) || substr( $haystack, -strlen( $needle ) ) === $needle;
 	}
 }
-/**
- * Polyfill for str_starts_with() function
- * Available natively in PHP 8.0+
- *
- * Checks if a string starts with a given substring
- *
- * @param string $haystack The string to search in
- * @param string $needle The substring to search for
- * @return bool Returns true if haystack starts with needle, false otherwise
- */
+
 if ( ! function_exists( 'str_starts_with' ) ) {
+	/**
+	 * Polyfill for str_starts_with() function
+	 * Available natively in PHP 8.0+
+	 *
+	 * Checks if a string starts with a given substring
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle The substring to search for.
+	 * @throws InvalidArgumentException If either argument is not a string.
+	 * @return bool Returns true if haystack starts with needle, false otherwise
+	 */
 	function str_starts_with( $haystack, $needle ) {
 		if ( ! is_string( $haystack ) || ! is_string( $needle ) ) {
 			throw new InvalidArgumentException( 'str_starts_with(): Arguments must be strings' );
 		}
 
-		// Empty needle always returns true (matches PHP 8.0+ behavior)
-		if ( $needle === '' ) {
+		// Empty needle always returns true (matches PHP 8.0+ behavior).
+		if ( '' === $needle ) {
 			return true;
 		}
 

--- a/doofinder-for-woocommerce/includes/polyfills.php
+++ b/doofinder-for-woocommerce/includes/polyfills.php
@@ -57,9 +57,9 @@ if ( ! function_exists( 'str_ends_with' ) ) {
  */
 if ( ! function_exists( 'str_starts_with' ) ) {
 	function str_starts_with( $haystack, $needle ) {
-		if (!is_string($haystack) || !is_string($needle)) {
-            throw new InvalidArgumentException('str_starts_with(): Arguments must be strings');
-        }
+		if ( ! is_string( $haystack ) || ! is_string( $needle ) ) {
+			throw new InvalidArgumentException( 'str_starts_with(): Arguments must be strings' );
+		}
 
 		// Empty needle always returns true (matches PHP 8.0+ behavior)
 		if ( $needle === '' ) {

--- a/doofinder-for-woocommerce/includes/polyfills.php
+++ b/doofinder-for-woocommerce/includes/polyfills.php
@@ -57,15 +57,15 @@ if ( ! function_exists( 'str_ends_with' ) ) {
  */
 if ( ! function_exists( 'str_starts_with' ) ) {
 	function str_starts_with( $haystack, $needle ) {
-		if ( ! is_string( $haystack ) || ! is_string( $needle ) ) {
-			throw new TypeError( 'str_starts_with(): Arguments must be strings' );
-		}
+		if (!is_string($haystack) || !is_string($needle)) {
+            throw new InvalidArgumentException('str_starts_with(): Arguments must be strings');
+        }
 
 		// Empty needle always returns true (matches PHP 8.0+ behavior)
 		if ( $needle === '' ) {
 			return true;
 		}
 
-		return strpos( $haystack, $needle ) === 0;
+		return 0 === strpos( $haystack, $needle );
 	}
 }

--- a/doofinder-for-woocommerce/includes/polyfills.php
+++ b/doofinder-for-woocommerce/includes/polyfills.php
@@ -48,24 +48,24 @@ if ( ! function_exists( 'str_ends_with' ) ) {
 /**
  * Polyfill for str_starts_with() function
  * Available natively in PHP 8.0+
- * 
+ *
  * Checks if a string starts with a given substring
  *
  * @param string $haystack The string to search in
  * @param string $needle The substring to search for
  * @return bool Returns true if haystack starts with needle, false otherwise
  */
-if (!function_exists('str_starts_with')) {
-    function str_starts_with($haystack, $needle) {
-        if (!is_string($haystack) || !is_string($needle)) {
-            throw new TypeError('str_starts_with(): Arguments must be strings');
-        }
+if ( ! function_exists( 'str_starts_with' ) ) {
+	function str_starts_with( $haystack, $needle ) {
+		if ( ! is_string( $haystack ) || ! is_string( $needle ) ) {
+			throw new TypeError( 'str_starts_with(): Arguments must be strings' );
+		}
 
 		// Empty needle always returns true (matches PHP 8.0+ behavior)
-        if ($needle === '') {
-            return true;
-        }
+		if ( $needle === '' ) {
+			return true;
+		}
 
-        return strpos($haystack, $needle) === 0;
-    }
+		return strpos( $haystack, $needle ) === 0;
+	}
 }

--- a/doofinder-for-woocommerce/includes/polyfills.php
+++ b/doofinder-for-woocommerce/includes/polyfills.php
@@ -45,3 +45,26 @@ if ( ! function_exists( 'str_ends_with' ) ) {
 		return 0 === strlen( $needle ) || substr( $haystack, -strlen( $needle ) ) === $needle;
 	}
 }
+/**
+ * Polyfill for str_starts_with() function
+ * Available natively in PHP 8.0+
+ * 
+ * Checks if a string starts with a given substring
+ *
+ * @param string $haystack The string to search in
+ * @param string $needle The substring to search for
+ * @return bool Returns true if haystack starts with needle, false otherwise
+ */
+if (!function_exists('str_starts_with')) {
+    function str_starts_with($haystack, $needle) {
+        if (!is_string($haystack) || !is_string($needle)) {
+            throw new TypeError('str_starts_with(): Arguments must be strings');
+        }
+
+        if ($needle === '') {
+            return true;
+        }
+
+        return strpos($haystack, $needle) === 0;
+    }
+}

--- a/doofinder-for-woocommerce/includes/polyfills.php
+++ b/doofinder-for-woocommerce/includes/polyfills.php
@@ -61,6 +61,7 @@ if (!function_exists('str_starts_with')) {
             throw new TypeError('str_starts_with(): Arguments must be strings');
         }
 
+		// Empty needle always returns true (matches PHP 8.0+ behavior)
         if ($needle === '') {
             return true;
         }

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.7.7
+Version: 2.7.8
 Requires at least: 5.6
 Tested up to: 6.8
 Requires PHP: 7.0
-Stable tag: 2.7.7
+Stable tag: 2.7.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.7.8 =
+- Include parent category paths in the `category_merchandising` field.
 
 = 2.7.7 =
 - Remove slashes from `category_merchandising` slugs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.7.7",
+  "version": "2.7.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.7.7",
+      "version": "2.7.8",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.7.7",
+  "version": "2.7.8",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Instead of returning only the links to the categories assigned to the product, we also return the links to the parent categories. We've also removed the base category from the paths. 

Example:
- Before:
   ```
   [
    'product-category/sales/man-sales', 
    'product-category/hoodies/special-hoodies'
  ]
   ```
- Now:
  ```
   [
    'sales', 
    'sales/man-sales', 
    'hoodies', 
    'hoodies/special-hoodies'
  ]
  ```