### PR TITLE
PLUGINRANGERS-377 | Added use statement for our Log class

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.7.8
+ * Version: 2.7.9
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -14,8 +14,9 @@
 
 namespace Doofinder\WP;
 
-use Doofinder\WP\Multilanguage\Multilanguage;
 use Doofinder\WP\Admin_Notices;
+use Doofinder\WP\Multilanguage\Multilanguage;
+use Doofinder\WP\Log;
 use Doofinder\WP\Settings;
 use WP_Http;
 
@@ -40,7 +41,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.7.8';
+		public static $version = '2.7.9';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.7.8
+Version: 2.7.9
 Requires at least: 5.6
 Tested up to: 6.8
 Requires PHP: 7.0
-Stable tag: 2.7.8
+Stable tag: 2.7.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.7.9 =
+- Included Log class in `use` statement.
 
 = 2.7.8 =
 - Include parent category paths in the `category_merchandising` field.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.7.8",
+  "version": "2.7.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.7.8",
+      "version": "2.7.9",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.7.8",
+  "version": "2.7.9",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/doofinder-woocommerce/issues/377

To sum up, basically an user complains about having a fatal error due to our `Log` class not being recognized in the upgrader function of the root file, so I'm adding the `use` statement with the hope that this will solve the issue (But it's actually a "blind" correction since it always worked fine in my WP installation).