### PR TITLE
Check `type` to identify `simple` products

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.8.0
+ * Version: 2.8.1
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -41,7 +41,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.8.0';
+		public static $version = '2.8.1';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -718,7 +718,7 @@ class Endpoint_Product {
 		$all_variants     = array();
 
 		foreach ( $products as $product ) {
-			if ( ! empty( $product['parent_id'] ) ) {
+			if ( 'variable' === $product['type'] && ! empty( $product['parent_id'] ) ) {
 				$parent_id = (string) $product['parent_id'];
 				// Save all variants by parent.
 				if ( ! isset( $all_variants[ $parent_id ] ) ) {

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.8.0
+Version: 2.8.1
 Requires at least: 5.6
 Tested up to: 6.8
 Requires PHP: 7.0
-Stable tag: 2.8.0
+Stable tag: 2.8.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.8.1 =
+- Index `simple` products that have a `parent_id` set.
 
 = 2.8.0 =
 - Add `blog_id` and schemaless `url` to installation options for store identification.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixed https://github.com/doofinder/support/issues/3832 and https://github.com/doofinder/support/issues/3856.

Parece que existen clientes que tiene productos con `type = "simple"` pero que tienen un `parent_id` al que no le he encontrado singificado porque en Wordpress están como simples sin más. El problema que estábamos teniendo es que, como tienen un `parent_id`, se estaban tratando como variantes y el `merge_variants_into_parents()` no las estaba incluyendo porque, en esa página que se estaba iterando, no estaba el padre correspondiente (porque realmente es que no es "su padre" y no se saca al hacer `self::get_variations( $products );`. Para mí, es una mala configuración en estos casos pero igualmente lo podemos subsanar haciendo esto.