### PR TITLE
PLUGINRANGERS-3922 | Klaviyo + setup Wizard improvements

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.9.0
+ * Version: 2.9.1
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -41,7 +41,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.9.0';
+		public static $version = '2.9.1';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/class-klaviyo-integration.php
+++ b/doofinder-for-woocommerce/includes/class-klaviyo-integration.php
@@ -36,7 +36,7 @@ class Klaviyo_Integration {
 	 * Klaviyo constructor.
 	 */
 	public function __construct() {
-		$this->enqueue_script();
+		$this->maybe_enqueue_script();
 	}
 
 	/**
@@ -44,7 +44,11 @@ class Klaviyo_Integration {
 	 *
 	 * @since 2.7.1
 	 */
-	public function enqueue_script() {
+	public function maybe_enqueue_script() {
+		if ( ! class_exists( 'WooCommerceKlaviyo' ) ) {
+			return;
+		}
+
 		add_action(
 			'wp_enqueue_scripts',
 			function () {

--- a/doofinder-for-woocommerce/includes/class-setup-wizard.php
+++ b/doofinder-for-woocommerce/includes/class-setup-wizard.php
@@ -339,17 +339,6 @@ class Setup_Wizard {
 	}
 
 	/**
-	 * Deactivate the setup wizard and set the flag making sure
-	 * to not display it anymore.
-	 */
-	public static function deactivate() {
-		update_option( self::$wizard_active_option, false );
-		update_option( self::$wizard_done_option, true );
-		update_option( self::$wizard_show_notice_option, false );
-		update_option( self::$wizard_show_indexing_notice_option, false );
-	}
-
-	/**
 	 * Dissmiss the admin setup wizard notice and set the flag making sure
 	 * to not display it anymore.
 	 */
@@ -460,6 +449,7 @@ class Setup_Wizard {
 			// Update wizard status to finished if configuration is complete.
 			if ( Settings::is_configuration_complete() ) {
 				update_option( self::$wizard_status, self::$wizard_status_finished );
+				update_option( self::$wizard_done_option, true );
 			}
 
 			?>

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.9.0
+Version: 2.9.1
 Requires at least: 5.6
 Tested up to: 6.8
 Requires PHP: 7.0
-Stable tag: 2.9.0
+Stable tag: 2.9.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,10 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.9.1 =
+- Prevent loading Klaviyo-related JS if Klaviyo plugin is not enabled.
+- Avoid calling Setup Wizard after finishing the initial setup.
 
 = 2.9.0 =
 - Fixed a bug when retrieving and saving data from the Store Wizard with WPML plugin active.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/3922

This one might not solve the linked support issue, but it's a neceessary fix to apply anyway. In this PR there are actually two fixes:

- The one described in the issue, which is to add an option to prevent calling multiple time the Doofinder plugin setup Wizard
- Another one discussed with Renzo regarding Klaviyo JS. We should not load the Klaviyo custom var if the Klaviyo plugin is not active.

The original function was called long time ago, but the call was removed here: https://github.com/doofinder/doofinder-woocommerce/commit/f2579ed1b2316f491f701077cac05865005a7aa9#diff-adf83a38abba9ba2415ffe8d30b8ad7e450afdbc38ba4f634d4b7491b6acb8faL487