### PR TITLE
Enable Xdebug to start with request

### DIFF
--- a/files-to-copy/usr/local/etc/php/conf.d/xdebug.ini
+++ b/files-to-copy/usr/local/etc/php/conf.d/xdebug.ini
@@ -7,5 +7,6 @@ xdebug.client_port=9003
 # The line below is commented. This is the IP of your host machine, where your IDE is installed.
 # We set this IP via XDEBUG_CONFIG environment variable in docker-compose.yml instead.
 xdebug.client_host=172.17.0.1
+xdebug.start_with_request=yes
 
 


### PR DESCRIPTION
This bit from https://github.com/doofinder/doofinder-woocommerce/pull/399/commits/50c98823fccafb982dd7266914c8f12c410a6587 was lost by the recent closing of https://github.com/doofinder/doofinder-woocommerce/pull/399. 

It allows Xdebug to start when an endpoint is reached without the need for a explicit trigger variable.