### PR TITLE
PLUGINRANGERS-4482 | Prevent fatal error on Log instantiation in upgrader function

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.10.8
+ * Version: 2.10.9
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -41,7 +41,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.10.8';
+		public static $version = '2.10.9';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress
@@ -291,6 +291,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @param array        $options Array of bulk item update data, like the action or the type.
 		 */
 		public static function upgrader_process_complete( $upgrader_object, $options ) {
+			self::autoload( self::plugin_path() . 'includes/' );
 			$log = new Log();
 			$log->log( 'upgrader_process - start' );
 			// The path to our plugin's main file.

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.10.8
+Version: 2.10.9
 Requires at least: 5.6
 Tested up to: 6.9
 Requires PHP: 7.0
-Stable tag: 2.10.8
+Stable tag: 2.10.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.10.9 =
+- Small fix in upgrader function.
 
 = 2.10.8 =
 - Tested features with WordPress 6.9

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.10.8",
+  "version": "2.10.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.10.8",
+      "version": "2.10.9",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.10.8",
+  "version": "2.10.9",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/4482

The `upgrader_process_complete` function is static, so the autoloader might not be called, thus the load of the next classes will fail in this case. This PR adds the autoloader directly on the function.

This has been already tested in a customer's WP uploading the fix via FTP.