### PR TITLE
Add filter to retrieve prices in default currency

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.10.9
+ * Version: 2.10.10
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -41,7 +41,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.10.9';
+		public static $version = '2.10.10';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.10.9
+Version: 2.10.10
 Requires at least: 5.6
 Tested up to: 6.9
 Requires PHP: 7.0
-Stable tag: 2.10.9
+Stable tag: 2.10.10
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.10.10 =
+- Fix WooPayments multi-currency price conversion for Doofinder requests. Prices are now returned in the store's default currency instead of being converted based on request geolocation.
 
 = 2.10.9 =
 - Small fix in upgrader function.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.10.9",
+  "version": "2.10.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.10.9",
+      "version": "2.10.10",
       "license": "MIT",
       "devDependencies": {
         "grunt": "^1.0.1",
@@ -877,7 +877,6 @@
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
       "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "dateformat": "~4.6.2",
         "eventemitter2": "~0.4.13",
@@ -3280,7 +3279,6 @@
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
       "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "dateformat": "~4.6.2",
         "eventemitter2": "~0.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.10.9",
+  "version": "2.10.10",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Closes https://github.com/doofinder/support/issues/4543

Al tener activo el plugin WooPayments con multi-currency, los precios de los productos se estaban calculando en función de la geolocalización de la petición. 

Como las peticiones de indexación salen desde servidores ubicados en Irlanda, WooPayments convertía automáticamente los precios a EUR, aplicando además las reglas de redondeo que estuvieran configuradas, en lugar de devolver el precio base en la moneda por defecto de la tienda (en este caso, GBP).

Este fix añade un filtro para que WooPayments utilice siempre la moneda configurada como predeterminada en la tienda para generar los precios. 