### PR TITLE
PLUGINRANGERS-4843 | Avoided PHP Notice if Klaviyo is not fully configured

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
- * Version: 2.10.17
+ * Version: 2.10.18
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -41,7 +41,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.10.17';
+		public static $version = '2.10.18';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/class-klaviyo-integration.php
+++ b/doofinder-for-woocommerce/includes/class-klaviyo-integration.php
@@ -56,12 +56,13 @@ class Klaviyo_Integration {
 					wp_enqueue_script(
 						'doofinder-integration-klaviyo',
 						Doofinder_For_WordPress::plugin_url() . 'assets/js/doofinder-integration-klaviyo.js',
-						array( 'kl-identify-browser' ), // To prevent this to be loaded before Klaviyo plugin script.
+						array(),
 						Doofinder_For_WordPress::$version,
 						true
 					);
 				}
-			}
+			},
+			PHP_INT_MAX // To prevent this to be loaded before Klaviyo plugin script.
 		);
 	}
 }

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.10.17
+Version: 2.10.18
 Requires at least: 5.6
 Tested up to: 6.9
 Requires PHP: 7.0
-Stable tag: 2.10.17
+Stable tag: 2.10.18
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.10.18 =
+- Avoided a PHP Notice in the logs if Klaviyo is installed but not fully configured.
 
 = 2.10.17 =
 - Added the creation date to the product information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.10.17",
+  "version": "2.10.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.10.17",
+      "version": "2.10.18",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.10.17",
+  "version": "2.10.18",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/4843

Like the customer said, there was a PHP Notice due to the declared dependency, because it seems that Klaviyo plugin can be installed but not configured, so in that case the scripts are not loaded, so we were calling a non-existent dependency. Instead of relying on the dependency, we will trigger the action with the lower priority (so using the highest integer).

I've tested that the Notice disappears with this change and our script still is kept at the end (even without having to declare the deps explicitly):

<img width="2249" height="1129" alt="image" src="https://github.com/user-attachments/assets/8828fac4-2432-44bf-9572-dfc20016ce39" />
