### PR TITLE
feat: expose dfPlatform variable for WooCommerce

### DIFF
--- a/doofinder-for-woocommerce/includes/class-js-layer.php
+++ b/doofinder-for-woocommerce/includes/class-js-layer.php
@@ -114,6 +114,7 @@ class JS_Layer {
 		echo '  var dfPageType = ' . wp_json_encode( $page_type ) . ";\n"; // phpcs:ignore WordPress.Security.EscapeOutput
 		echo '  var dfProductId = ' . wp_json_encode( $product_id ) . ";\n"; // phpcs:ignore WordPress.Security.EscapeOutput
 		echo '  var dfCategoryName = ' . wp_json_encode( $category_name ) . ";\n"; // phpcs:ignore WordPress.Security.EscapeOutput
+		echo '  var dfPlatform = ' . wp_json_encode( 'woocommerce' ) . ";\n"; // phpcs:ignore WordPress.Security.EscapeOutput
 		echo "</script>\n"; // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 


### PR DESCRIPTION
## Summary
- Adds `var dfPlatform = 'woocommerce'` in `class-js-layer.php`
- Value matches doomanager's store `platform` field
- Allows apps-loader to map plugin values to Doofinder's standardized platform identifiers

## Related
- doofinder/dooplugins#2225

## Test plan
- [ ] Verify `window.dfPlatform === 'woocommerce'` on a WooCommerce storefront

🤖 Generated with [Claude Code](https://claude.com/claude-code)