### PR TITLE
PLUGINRANGERS-432 | Made custom endpoint able to discern between post types and taxonomies

### DIFF
--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
- * Version: 2.11.0
+ * Version: 2.12.0
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -41,7 +41,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.11.0';
+		public static $version = '2.12.0';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-custom.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-custom.php
@@ -112,51 +112,10 @@ class Endpoint_Custom {
 		$type = $config_request['type'] ?? '';
 
 		if ( taxonomy_exists( $type ) ) {
-			$taxonomy_fields = empty( $fields ) ? array() : self::TAXONOMY_FIELDS;
-			$items           = self::get_items( $config_request );
-
-			foreach ( $items as $item_data ) {
-				$filtered_data = ! empty( $taxonomy_fields )
-					? array_intersect_key( $item_data, array_flip( $taxonomy_fields ) )
-					: $item_data;
-
-				if ( in_array( 'image_link', $taxonomy_fields, true ) || empty( $taxonomy_fields ) ) {
-					$filtered_data['image_link'] = self::get_term_image_link( $item_data );
-				}
-
-				$modified_items[] = $filtered_data;
-			}
-
-			return new WP_REST_Response( $modified_items ?? array() );
+			return self::get_taxonomy( $request, $config_request, $fields );
 		}
 
-		$items = self::get_items( $config_request );
-
-		foreach ( $items as $item_data ) {
-
-			if ( 'noindex' === get_post_meta( $item_data['id'], '_doofinder_for_wp_indexing_visibility', true ) ) {
-				continue;
-			}
-
-			$custom_attr = Settings::get_post_custom_attributes();
-
-			$filtered_data = ! empty( $fields ) ? array_intersect_key( $item_data, array_flip( $fields ) ) : $item_data;
-
-			$filtered_data = self::get_title( $filtered_data );
-			$filtered_data = self::get_content( $filtered_data );
-			$filtered_data = self::get_description( $filtered_data );
-			$filtered_data = self::get_author( $filtered_data, $fields, $config_request );
-			$filtered_data = self::get_image_link( $filtered_data, $fields );
-			$filtered_data = self::get_post_tags( $filtered_data, $fields );
-			$filtered_data = self::get_categories( $filtered_data, $fields );
-			$filtered_data = self::get_meta_attributes( $filtered_data, $custom_attr );
-			$filtered_data = self::clear_unused_fields( $filtered_data );
-
-			$modified_items[] = $filtered_data;
-		}
-
-		// Return the modified items data as a response.
-		return new WP_REST_Response( $modified_items ?? array() );
+		return self::get_post_type( $config_request, $fields );
 	}
 
 	/**
@@ -194,6 +153,72 @@ class Endpoint_Custom {
 		);
 
 		return $items;
+	}
+
+	/**
+	 * Get the taxonomy data.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 * @param array           $config_request Array config for internal requests.
+	 * @param array           $fields The fields to include in the response.
+	 *
+	 * @return WP_REST_Response Response containing modified taxonomy data.
+	 */
+	private static function get_taxonomy( $request, $config_request, $fields ) {
+		$taxonomy_fields = empty( $fields ) ? array() : self::TAXONOMY_FIELDS;
+		$items           = self::get_items( $config_request );
+
+		foreach ( $items as $item_data ) {
+			$filtered_data = ! empty( $taxonomy_fields )
+				? array_intersect_key( $item_data, array_flip( $taxonomy_fields ) )
+				: $item_data;
+
+			if ( in_array( 'image_link', $taxonomy_fields, true ) || empty( $taxonomy_fields ) ) {
+				$filtered_data['image_link'] = self::get_term_image_link( $item_data );
+			}
+
+			$modified_items[] = $filtered_data;
+		}
+
+		return new WP_REST_Response( $modified_items ?? array() );
+	}
+
+	/**
+	 * Get the post type data.
+	 *
+	 * @param array $config_request Array config for internal requests.
+	 * @param array $fields The fields to include in the response.
+	 *
+	 * @return WP_REST_Response Response containing modified post type data.
+	 */
+	private static function get_post_type( $config_request, $fields ) {
+		$items = self::get_items( $config_request );
+
+		foreach ( $items as $item_data ) {
+
+			if ( 'noindex' === get_post_meta( $item_data['id'], '_doofinder_for_wp_indexing_visibility', true ) ) {
+				continue;
+			}
+
+			$custom_attr = Settings::get_post_custom_attributes();
+
+			$filtered_data = ! empty( $fields ) ? array_intersect_key( $item_data, array_flip( $fields ) ) : $item_data;
+
+			$filtered_data = self::get_title( $filtered_data );
+			$filtered_data = self::get_content( $filtered_data );
+			$filtered_data = self::get_description( $filtered_data );
+			$filtered_data = self::get_author( $filtered_data, $fields, $config_request );
+			$filtered_data = self::get_image_link( $filtered_data, $fields );
+			$filtered_data = self::get_post_tags( $filtered_data, $fields );
+			$filtered_data = self::get_categories( $filtered_data, $fields );
+			$filtered_data = self::get_meta_attributes( $filtered_data, $custom_attr );
+			$filtered_data = self::clear_unused_fields( $filtered_data );
+
+			$modified_items[] = $filtered_data;
+		}
+
+		// Return the modified items data as a response.
+		return new WP_REST_Response( $modified_items ?? array() );
 	}
 
 	/**

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-custom.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-custom.php
@@ -35,6 +35,15 @@ class Endpoint_Custom {
 		'title',
 	);
 
+	const TAXONOMY_FIELDS = array(
+		'description',
+		'id',
+		'image_link',
+		'link',
+		'name',
+		'parent',
+		'slug',
+	);
 
 	/**
 	 * Initialize the custom item endpoint.
@@ -98,6 +107,27 @@ class Endpoint_Custom {
 			}
 
 			$fields = ! empty( $config_request['fields'] ) ? explode( ',', $config_request['fields'] ) : array();
+		}
+
+		$type = $config_request['type'] ?? '';
+
+		if ( taxonomy_exists( $type ) ) {
+			$taxonomy_fields = empty( $fields ) ? array() : self::TAXONOMY_FIELDS;
+			$items           = self::get_items( $config_request );
+
+			foreach ( $items as $item_data ) {
+				$filtered_data = ! empty( $taxonomy_fields )
+					? array_intersect_key( $item_data, array_flip( $taxonomy_fields ) )
+					: $item_data;
+
+				if ( in_array( 'image_link', $taxonomy_fields, true ) || empty( $taxonomy_fields ) ) {
+					$filtered_data['image_link'] = self::get_term_image_link( $item_data );
+				}
+
+				$modified_items[] = $filtered_data;
+			}
+
+			return new WP_REST_Response( $modified_items ?? array() );
 		}
 
 		$items = self::get_items( $config_request );
@@ -419,12 +449,25 @@ class Endpoint_Custom {
 	/**
 	 * Retrieve a list of items with pagination.
 	 *
+	 * Handles both post types and taxonomies: for taxonomies the REST base is
+	 * resolved via get_taxonomy() since it may differ from the taxonomy slug
+	 * (e.g. 'category' → 'categories').
+	 *
 	 * @param array $config_request Config request params (page, per_page, type).
 	 * @return array|null   An array of items data or null on failure.
 	 */
 	private static function get_items( $config_request ) {
+		$type = $config_request['type'];
+
+		if ( taxonomy_exists( $type ) ) {
+			$taxonomy_obj = get_taxonomy( $type );
+			$rest_base    = ! empty( $taxonomy_obj->rest_base ) ? $taxonomy_obj->rest_base : $type;
+		} else {
+			$rest_base = $type;
+		}
+
 		// Retrieve the original items data.
-		$request = new WP_REST_Request( 'GET', '/wp/v2/' . $config_request['type'] );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/' . $rest_base );
 		$request->set_query_params(
 			array(
 				'page'     => ! empty( $config_request['page'] ) ? $config_request['page'] : 1,
@@ -464,5 +507,26 @@ class Endpoint_Custom {
 		}
 
 		return $meta_data;
+	}
+
+	/**
+	 * Returns the image link for a given taxonomy term.
+	 *
+	 * Looks up the term's thumbnail_id meta key, which is the standard used by
+	 * WooCommerce product categories and similar taxonomies. Returns an empty string
+	 * if no image is associated with the term.
+	 *
+	 * @param array $term Term data as an array containing at least 'id'.
+	 * @return string The image URL, or empty string if no image is found.
+	 */
+	private static function get_term_image_link( $term ) {
+		$thumbnail_id = get_term_meta( $term['id'], 'thumbnail_id', true );
+		$image_link   = empty( $thumbnail_id ) ? '' : wp_get_attachment_url( $thumbnail_id );
+
+		if ( empty( $image_link ) ) {
+			return '';
+		}
+
+		return self::add_base_url_if_needed( $image_link );
 	}
 }

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product-category.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product-category.php
@@ -5,31 +5,16 @@
  * @package Doofinder\WP\Endpoints
  */
 
-use Doofinder\WP\Endpoints;
-use Doofinder\WP\Helpers\Helpers;
-use Doofinder\WP\Multilanguage;
-use Doofinder\WP\Thumbnail;
-
 /**
  * Class Endpoint_Product_Category
  *
- * This class defines various methods for handling item WordPress endpoints.
+ * This is kept for backward compatibility, it will call the Endpoint_Custom class to handle the request, but it will be removed in the future.
  */
 class Endpoint_Product_Category {
 
 	const PER_PAGE = 100;
 	const CONTEXT  = 'doofinder/v1';
 	const ENDPOINT = '/product_category';
-	const FIELDS   = array(
-		'description',
-		'_embedded',
-		'id',
-		'image_link',
-		'link',
-		'name',
-		'parent',
-		'slug',
-	);
 
 	/**
 	 * Initialize the custom item endpoint.
@@ -60,103 +45,6 @@ class Endpoint_Product_Category {
 	 * @return WP_REST_Response Response containing modified data.
 	 */
 	public static function product_category_endpoint( $request ) {
-
-		Endpoints::check_secure_token();
-
-		$multilanguage = Multilanguage::instance();
-
-		$config_request['per_page'] = $request->get_param( 'per_page' ) ?? self::PER_PAGE;
-		$config_request['page']     = $request->get_param( 'page' ) ?? 1;
-		if ( $multilanguage->is_active() ) {
-			$locale_or_lang_code    = $request->get_param( 'lang' ) ?? '';
-			$lang_code              = Helpers::apply_locale_to_rest_context( $locale_or_lang_code );
-			$config_request['lang'] = $lang_code;
-		}
-		$config_request['fields'] = ( 'all' === $request->get_param( 'fields' ) ) ? '' : implode( ',', self::get_fields() );
-
-		// Get the 'fields' parameter from the request.
-		$fields = ! empty( $config_request['fields'] ) ? self::get_fields() : array();
-
-		// Retrieve the original items data.
-		$items = self::get_items( $config_request );
-
-		if ( ! empty( $items ) ) {
-			foreach ( $items as &$item_data ) {
-
-				if ( in_array( 'image_link', $fields, true ) || empty( $fields ) ) {
-					$item_data['image_link'] = self::get_product_cat_df_image_link( $item_data );
-				}
-			}
-		}
-
-		// Return the modified items data as a response.
-		return new WP_REST_Response( $items );
-	}
-
-	/**
-	 * Get the array of fields.
-	 *
-	 * @return array The array of fields.
-	 */
-	public static function get_fields() {
-		return self::FIELDS;
-	}
-
-	/**
-	 * Check that image link is absolute, if not, add the site url
-	 *
-	 * @param string $image_link URL of the image.
-	 *
-	 * @return string $image_link
-	 */
-	private static function add_base_url_if_needed( $image_link ) {
-		if ( 0 === strpos( $image_link, '/' ) ) {
-			$image_link = get_site_url() . $image_link;
-		}
-		return $image_link;
-	}
-
-	/**
-	 * Returns the image link for a given term.
-	 *
-	 * @param array $term WordPress Term as array.
-	 *
-	 * @return string The image link.
-	 */
-	public static function get_product_cat_df_image_link( $term ) {
-		// get the thumbnail id using the queried category term_id.
-		$thumbnail_id = get_term_meta( $term['id'], 'thumbnail_id', true );
-		$image_link   = empty( $thumbnail_id ) ? '' : wp_get_attachment_url( $thumbnail_id );
-		$image_link   = empty( $image_link ) ? wc_placeholder_img_src( Thumbnail::get_size() ) : $image_link;
-		$image_link   = self::add_base_url_if_needed( $image_link );
-		return $image_link;
-	}
-
-	/**
-	 * Retrieve a list of items with pagination.
-	 *
-	 * @param array $config_request Config request params (page, per_page, type).
-	 *
-	 * @return array|null   An array of items data or null on failure.
-	 */
-	private static function get_items( $config_request ) {
-		// Retrieve the original items data.
-		$request = new WP_REST_Request( 'GET', '/wp/v2/product_cat' );
-		$request->set_query_params(
-			array(
-				'page'     => $config_request['page'],
-				'per_page' => $config_request['per_page'],
-				'lang'     => $config_request['lang'],
-				'_fields'  => $config_request['fields'],
-			)
-		);
-		$response = rest_do_request( $request );
-		$data     = rest_get_server()->response_to_data( $response, true );
-
-		if ( ! empty( $data['data']['status'] ) && WP_Http::OK !== $data['data']['status'] ) {
-			$data = array();
-		}
-
-		return $data;
+		return Endpoint_Custom::custom_endpoint( $request );
 	}
 }

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product-category.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product-category.php
@@ -45,6 +45,7 @@ class Endpoint_Product_Category {
 	 * @return WP_REST_Response Response containing modified data.
 	 */
 	public static function product_category_endpoint( $request ) {
+		$request->set_param( 'type', 'product_cat' );
 		return Endpoint_Custom::custom_endpoint( $request );
 	}
 }

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product-category.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product-category.php
@@ -39,7 +39,9 @@ class Endpoint_Product_Category {
 	}
 
 	/**
-	 * Custom item endpoint callback.
+	 * Custom item endpoint callback. It has been kept due to backward compatibility purposes.
+	 * Since the product category is a taxonomy, it will set the type parameter to 'product_cat'
+	 * and call the Endpoint_Custom class to handle the request like the rest of taxonomies.
 	 *
 	 * @param WP_REST_Request $request The REST request object.
 	 * @return WP_REST_Response Response containing modified data.

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product-category.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product-category.php
@@ -8,7 +8,9 @@
 /**
  * Class Endpoint_Product_Category
  *
- * This is kept for backward compatibility, it will call the Endpoint_Custom class to handle the request, but it will be removed in the future.
+ * This is kept for backward compatibility, it will call the Endpoint_Custom class to handle the request,
+ * but it will be removed in the future when all the customers have updated the plugin to at least version 2.12.0
+ * and when we apply a change in our internal services.
  */
 class Endpoint_Product_Category {
 

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.11.0
+Version: 2.12.0
 Requires at least: 5.6
 Tested up to: 6.9
 Requires PHP: 7.0
-Stable tag: 2.11.0
+Stable tag: 2.12.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.12.0 =
+- The custom endpoint is now able to detect automatically if the type passed is a taxonomy or a post type.
 
 = 2.11.0 =
 - Exposed information about the actual frontend page to be used for statistics.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/doofinder-woocommerce/issues/432

Thanks to this simplification I was able to simplify product category endpoint a lot, but unfortunately it is not possible to remove it completely yet since our services are calling it and stopping calling it would be a breaking change (at least, until all the customers have this version or higher)