### PR TITLE
Acova/doofinder woocommerce/1297/improve local integration

### DIFF
--- a/.env
+++ b/.env
@@ -35,6 +35,6 @@ FS_METHOD=direct
 # over `templates/` to regenerate the committed plugin source files. Bump
 # PLUGIN_VERSION here for releases; override the URL formats in .env.local
 # to point the plugin at your own ngrok stack during dev.
-PLUGIN_VERSION=2.15.0
+PLUGIN_VERSION=2.15.1
 DOOFINDER_PLUGINS_URL_FORMAT=https://%splugins.doofinder.com
 DOOFINDER_API_URL_FORMAT=https://%sadmin.doofinder.com

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
- * Version: 2.15.0
+ * Version: 2.15.1
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -44,7 +44,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.15.0';
+		public static $version = '2.15.1';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/class-doofinder-constants.php
+++ b/doofinder-for-woocommerce/includes/class-doofinder-constants.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Doofinder_Constants {
 
-	const VERSION            = '2.15.0';
+	const VERSION            = '2.15.1';
 	const PLUGINS_URL_FORMAT = 'https://%splugins.doofinder.com';
 	const API_URL_FORMAT     = 'https://%sadmin.doofinder.com';
 }

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.15.0
+Version: 2.15.1
 Requires at least: 5.6
 Tested up to: 6.9
 Requires PHP: 7.0
-Stable tag: 2.15.0
+Stable tag: 2.15.1
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.15.1 =
+- Fixed bug that didn't allow for the builds to be finished.
 
 = 2.15.0 =
 - Added Makefile-driven local development.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.15.0",
+      "version": "2.15.1",
       "license": "MIT",
       "devDependencies": {
         "coffeescript": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "grunt release"
+    "build": "grunt build"
   },
   "repository": {
     "type": "git",

--- a/templates/doofinder-for-woocommerce/readme.txt
+++ b/templates/doofinder-for-woocommerce/readme.txt
@@ -126,6 +126,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= 2.15.1 =
+- Fixed bug that didn't allow for the builds to be finished.
+
 = 2.15.0 =
 - Added Makefile-driven local development.
 - Added support for e2e testing.


### PR DESCRIPTION
After the last PR, https://github.com/doofinder/doofinder-woocommerce/pull/441, using `grunt release` became redundant, as the process of updating the version metadata is done in the `make doofinder-configure` target. But that PR didn't change the action called when trying to update a new version, which made it so the build and deploy process failed.

This PR aims at fixing just that.