### PR TITLE
Parametrize layer script URL via envsubst

### DIFF
--- a/.env
+++ b/.env
@@ -38,3 +38,4 @@ FS_METHOD=direct
 PLUGIN_VERSION=2.15.1
 DOOFINDER_PLUGINS_URL_FORMAT=https://%splugins.doofinder.com
 DOOFINDER_API_URL_FORMAT=https://%sadmin.doofinder.com
+DOOFINDER_LAYER_SCRIPT_URL=https://cdn.doofinder.com/livelayer/1/js/loader.min.js

--- a/.github/workflows/template_drift_check.yml
+++ b/.github/workflows/template_drift_check.yml
@@ -31,7 +31,7 @@ jobs:
           set -a
           source .env
           set +a
-          ENVSUBST_VARS='$PLUGIN_VERSION,$DOOFINDER_PLUGINS_URL_FORMAT,$DOOFINDER_API_URL_FORMAT'
+          ENVSUBST_VARS='$PLUGIN_VERSION,$DOOFINDER_PLUGINS_URL_FORMAT,$DOOFINDER_API_URL_FORMAT,$DOOFINDER_LAYER_SCRIPT_URL'
           mkdir -p .drift-out/includes
           envsubst "$ENVSUBST_VARS" < templates/doofinder-for-woocommerce/doofinder-for-woocommerce.php > .drift-out/doofinder-for-woocommerce.php
           envsubst "$ENVSUBST_VARS" < templates/doofinder-for-woocommerce/readme.txt                       > .drift-out/readme.txt

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 docker_exec_web = $(docker_compose) exec wordpress
 wp = $(docker_exec_web) wpcli --path=/var/www/html --allow-root
 
-envsubst_vars = $$PLUGIN_VERSION,$$DOOFINDER_PLUGINS_URL_FORMAT,$$DOOFINDER_API_URL_FORMAT
+envsubst_vars = $$PLUGIN_VERSION,$$DOOFINDER_PLUGINS_URL_FORMAT,$$DOOFINDER_API_URL_FORMAT,$$DOOFINDER_LAYER_SCRIPT_URL
 
 # Default target: list available tasks
 all:

--- a/doofinder-for-woocommerce/includes/class-doofinder-constants.php
+++ b/doofinder-for-woocommerce/includes/class-doofinder-constants.php
@@ -26,4 +26,5 @@ class Doofinder_Constants {
 	const VERSION            = '2.15.1';
 	const PLUGINS_URL_FORMAT = 'https://%splugins.doofinder.com';
 	const API_URL_FORMAT     = 'https://%sadmin.doofinder.com';
+	const LAYER_SCRIPT_URL   = 'https://cdn.doofinder.com/livelayer/1/js/loader.min.js';
 }

--- a/doofinder-for-woocommerce/includes/class-js-layer.php
+++ b/doofinder-for-woocommerce/includes/class-js-layer.php
@@ -84,6 +84,7 @@ class JS_Layer {
 		TODO: When all the customer have migrated to the single script
 		this one should be adapted too.
 		*/
+		$layer = str_replace( 'https://cdn.doofinder.com/livelayer/1/js/loader.min.js', Doofinder_Constants::LAYER_SCRIPT_URL, $layer );
 		if ( defined( 'WP_ENVIRONMENT_TYPE' ) && WP_ENVIRONMENT_TYPE === 'local' && defined( 'DF_SEARCH_HOST' ) && defined( 'DF_LAYER_HOST' ) ) {
 			$local_constants = "<script>
     // FOR DEVELOPMENT PURPOSES ONLY!!!
@@ -92,7 +93,6 @@ class JS_Layer {
     var __DF_LAYER_SERVER__ = '" . DF_LAYER_HOST . "';
     var __DF_CDN_PREFIX__ =  '" . DF_LAYER_HOST . "/assets';";
 			$layer           = str_replace( '<script>', $local_constants, $layer );
-			$layer           = str_replace( 'https://cdn.doofinder.com/livelayer/1/js/loader.min.js', DF_LAYER_HOST . '/assets/js/loader.js', $layer );
 		}
 
 		$this->output_page_context_variables();

--- a/templates/doofinder-for-woocommerce/includes/class-doofinder-constants.php
+++ b/templates/doofinder-for-woocommerce/includes/class-doofinder-constants.php
@@ -26,4 +26,5 @@ class Doofinder_Constants {
 	const VERSION            = '${PLUGIN_VERSION}';
 	const PLUGINS_URL_FORMAT = '${DOOFINDER_PLUGINS_URL_FORMAT}';
 	const API_URL_FORMAT     = '${DOOFINDER_API_URL_FORMAT}';
+	const LAYER_SCRIPT_URL   = '${DOOFINDER_LAYER_SCRIPT_URL}';
 }


### PR DESCRIPTION
## Summary
- Added `DOOFINDER_LAYER_SCRIPT_URL` env var to `.env` (defaults to the production CDN URL) and the Makefile `envsubst_vars`
- Added `LAYER_SCRIPT_URL` constant to `class-doofinder-constants.php` template, populated at build time by `make doofinder-configure`
- Updated `class-js-layer.php` to use `Doofinder_Constants::LAYER_SCRIPT_URL` for the loader URL replacement instead of the hardcoded CDN string; replacement is now unconditional (no-op in production) and decoupled from `DF_LAYER_HOST`

To use locally, set `DOOFINDER_LAYER_SCRIPT_URL=<local-url>` in `.env.local` and run `make doofinder-configure`.