### PR TITLE
Stop WooCommerce indexing spinner when a failure callback arrives

### DIFF
--- a/.env
+++ b/.env
@@ -35,6 +35,6 @@ FS_METHOD=direct
 # over `templates/` to regenerate the committed plugin source files. Bump
 # PLUGIN_VERSION here for releases; override the URL formats in .env.local
 # to point the plugin at your own ngrok stack during dev.
-PLUGIN_VERSION=2.15.1
+PLUGIN_VERSION=2.15.2
 DOOFINDER_PLUGINS_URL_FORMAT=https://%splugins.doofinder.com
 DOOFINDER_API_URL_FORMAT=https://%sadmin.doofinder.com

--- a/doofinder-for-woocommerce/assets/js/admin.js
+++ b/doofinder-for-woocommerce/assets/js/admin.js
@@ -14,7 +14,7 @@ jQuery(function () {
           $(".indexation-status").toggleClass("processing processed");
           clearInterval(indexingCheckInterval);
         }
-        if (response.status === "timed-out") {
+        if (response.status === "timed-out" || response.status === "failed") {
           $("#df-indexing-status").remove();
           clearInterval(indexingCheckInterval);
         }

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -405,7 +405,9 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 					$lang          = ( $multilanguage->get_current_language() === $multilanguage->get_base_language() ) ? '' : $multilanguage->get_current_language();
 					$status        = Settings::get_indexing_status( $lang );
 
-					if ( Index_Status_Handler::is_indexing_status_timed_out( $lang ) ) {
+					// Only the 'processing' status can time out; terminal statuses
+					// such as 'failed' or 'processed' must be reported as-is.
+					if ( 'processing' === $status && Index_Status_Handler::is_indexing_status_timed_out( $lang ) ) {
 						Setup_Wizard::dismiss_indexing_notice();
 						$status = 'timed-out';
 						Settings::set_indexing_status( $status, $lang );

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
- * Version: 2.15.1
+ * Version: 2.15.2
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -44,7 +44,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.15.1';
+		public static $version = '2.15.2';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/class-doofinder-constants.php
+++ b/doofinder-for-woocommerce/includes/class-doofinder-constants.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Doofinder_Constants {
 
-	const VERSION            = '2.15.1';
+	const VERSION            = '2.15.2';
 	const PLUGINS_URL_FORMAT = 'https://%splugins.doofinder.com';
 	const API_URL_FORMAT     = 'https://%sadmin.doofinder.com';
 }

--- a/doofinder-for-woocommerce/includes/class-index-status-handler.php
+++ b/doofinder-for-woocommerce/includes/class-index-status-handler.php
@@ -69,12 +69,17 @@ class Index_Status_Handler {
 			);
 		}
 
+		$multilanguage = Multilanguage::instance();
+		$lang          = ( $multilanguage->get_current_language() === $multilanguage->get_base_language() ) ? '' : $multilanguage->get_current_language();
+
 		$error_message = $request->get_param( 'message' );
 		if ( ! empty( $error_message ) && $error_message !== $valid_message ) {
 			$notice_title   = __( 'An error has occurred while indexing your catalog', 'wordpress-doofinder' );
 			$notice_content = __( 'To obtain further details, you can check the indexing results by accessing the "Indices" section in your Doofinder admin panel. If the problem persists, please contact our support team at <a href="mailto:support@doofinder.com">support@doofinder.com</a>', 'wordpress-doofinder' );
 			// Dismiss the indexing notice as it has already finished.
 			Setup_Wizard::dismiss_indexing_notice();
+			// Persist a terminal status so the spinner stops and the notice does not reappear.
+			Settings::set_indexing_status( 'failed', $lang );
 			Admin_Notices::add_notice( 'indexing-status-failed', $notice_title, $notice_content, 'error', null, '', true );
 
 			return new WP_REST_Response(
@@ -86,8 +91,6 @@ class Index_Status_Handler {
 			);
 		}
 
-		$multilanguage = Multilanguage::instance();
-		$lang          = ( $multilanguage->get_current_language() === $multilanguage->get_base_language() ) ? '' : $multilanguage->get_current_language();
 		// Hide the indexing notice.
 		Setup_Wizard::dismiss_indexing_notice();
 		Settings::set_indexing_status( 'processed', $lang );

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.15.1
+Version: 2.15.2
 Requires at least: 5.6
 Tested up to: 6.9
 Requires PHP: 7.0
-Stable tag: 2.15.1
+Stable tag: 2.15.2
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -125,6 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
+= 2.15.2 =
+- Fixed the indexing status banner so the spinner stops when an indexation failure is reported.
 
 = 2.15.1 =
 - Fixed bug that didn't allow for the builds to be finished.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "doofinder-woocommerce",
-      "version": "2.15.1",
+      "version": "2.15.2",
       "license": "MIT",
       "devDependencies": {
         "coffeescript": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-woocommerce",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "description": "Integrate Doofinder in your WooCommerce site with (almost) no effort.",
   "main": "index.js",
   "scripts": {

--- a/templates/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/templates/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -405,7 +405,9 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 					$lang          = ( $multilanguage->get_current_language() === $multilanguage->get_base_language() ) ? '' : $multilanguage->get_current_language();
 					$status        = Settings::get_indexing_status( $lang );
 
-					if ( Index_Status_Handler::is_indexing_status_timed_out( $lang ) ) {
+					// Only the 'processing' status can time out; terminal statuses
+					// such as 'failed' or 'processed' must be reported as-is.
+					if ( 'processing' === $status && Index_Status_Handler::is_indexing_status_timed_out( $lang ) ) {
 						Setup_Wizard::dismiss_indexing_notice();
 						$status = 'timed-out';
 						Settings::set_indexing_status( $status, $lang );

--- a/templates/doofinder-for-woocommerce/readme.txt
+++ b/templates/doofinder-for-woocommerce/readme.txt
@@ -126,6 +126,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= 2.15.2 =
+- Fixed the indexing status banner so the spinner stops when an indexation failure is reported.
+
 = 2.15.1 =
 - Fixed bug that didn't allow for the builds to be finished.
 


### PR DESCRIPTION
Closes doofinder/support#5042

When the WooCommerce setup wizard is running, an admin banner with a spinner signals indexing in progress. If dftasks reports a per-index feed failure (a callback with a non-success `message`), the plugin previously dismissed the stored notice but never persisted a terminal status, so the stored status stayed `processing`. Combined with the JS poller only understanding `processed`/`timed-out`, the spinner kept spinning on any open admin page until a manual reload or the 12-hour timeout.

This PR fixes the failure-callback path in the WooCommerce plugin only:

- On a failure callback, a terminal `failed` status is now written, so the stored state correctly reflects the outcome.
- The AJAX timeout override is guarded to `processing` status only, so a terminal `failed` or `processed` is reported as-is rather than being clobbered to `timed-out`.
- The JS poller now treats `failed` identically to `timed-out`: it removes the notice and stops polling, so the open admin page self-heals within ~10 seconds.

## Scope & limitations (intentional)

- **dftasks is intentionally unchanged.** An earlier approach had dftasks emit a callback on hard failures, but that would make PrestaShop (whose callback marks the feed indexed on *any* POST, regardless of body) treat a failure as success. Leaving dftasks byte-identical guarantees zero regression for every deployed plugin (WooCommerce, Magento 2, Shopware 5, PrestaShop).
- **This fixes only the case where a failure callback actually arrives** (per-index feed errors). The open page self-heals within ~10s and a correct terminal status is recorded.
- **It does not address the "no callback ever arrives" case** (hard crash or early error in dftasks, or a reindex triggered from doomanager without a `callback_url`). That path still relies on the existing 12-hour timeout. If [support#5042](https://github.com/doofinder/support/issues/5042) recurs via that path, this PR won't prevent it. But at least Support now knows how to use curl to trigger the callback. 