### PR TITLE
Christian/446 indexing failure meta field

### DIFF
--- a/.env
+++ b/.env
@@ -35,6 +35,6 @@ FS_METHOD=direct
 # over `templates/` to regenerate the committed plugin source files. Bump
 # PLUGIN_VERSION here for releases; override the URL formats in .env.local
 # to point the plugin at your own ngrok stack during dev.
-PLUGIN_VERSION=2.15.2
+PLUGIN_VERSION=2.15.3
 DOOFINDER_PLUGINS_URL_FORMAT=https://%splugins.doofinder.com
 DOOFINDER_API_URL_FORMAT=https://%sadmin.doofinder.com

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
- * Version: 2.15.2
+ * Version: 2.15.3
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -44,7 +44,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.15.2';
+		public static $version = '2.15.3';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -407,9 +407,7 @@ class Endpoint_Product {
 		if ( empty( $custom_attr ) ) {
 			return $data;
 		}
-
-		// $data comes from the REST API and must win on key collisions; custom attributes
-		// only fill in gaps (e.g. dimensions), since their postmeta fallback can be stale.
+		
 		$data_with_attr = array_merge( self::get_custom_attributes( $data['id'], $custom_attr ), $data );
 
 		foreach ( $custom_attr as $custom ) {

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -407,7 +407,7 @@ class Endpoint_Product {
 		if ( empty( $custom_attr ) ) {
 			return $data;
 		}
-		
+
 		$data_with_attr = array_merge( self::get_custom_attributes( $data['id'], $custom_attr ), $data );
 
 		foreach ( $custom_attr as $custom ) {

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -408,12 +408,8 @@ class Endpoint_Product {
 			return $data;
 		}
 
-		// `$data` (already fetched from the WooCommerce REST API) wins on key collisions.
-		// `get_custom_attributes()` falls back to raw postmeta (see get_all_attributes()),
-		// which can include WooCommerce's own internal/legacy meta keys (e.g. a stale
-		// `_featured` row); that fallback must only fill in fields the REST response didn't
-		// already provide (e.g. `length`/`width`/`height`, which WC nests under `dimensions`
-		// instead of returning as flat fields), never overwrite an authoritative REST value.
+		// $data comes from the REST API and must win on key collisions; custom attributes
+		// only fill in gaps (e.g. dimensions), since their postmeta fallback can be stale.
 		$data_with_attr = array_merge( self::get_custom_attributes( $data['id'], $custom_attr ), $data );
 
 		foreach ( $custom_attr as $custom ) {

--- a/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
+++ b/doofinder-for-woocommerce/includes/api/endpoints/class-endpoint-product.php
@@ -408,7 +408,13 @@ class Endpoint_Product {
 			return $data;
 		}
 
-		$data_with_attr = array_merge( $data, self::get_custom_attributes( $data['id'], $custom_attr ) );
+		// `$data` (already fetched from the WooCommerce REST API) wins on key collisions.
+		// `get_custom_attributes()` falls back to raw postmeta (see get_all_attributes()),
+		// which can include WooCommerce's own internal/legacy meta keys (e.g. a stale
+		// `_featured` row); that fallback must only fill in fields the REST response didn't
+		// already provide (e.g. `length`/`width`/`height`, which WC nests under `dimensions`
+		// instead of returning as flat fields), never overwrite an authoritative REST value.
+		$data_with_attr = array_merge( self::get_custom_attributes( $data['id'], $custom_attr ), $data );
 
 		foreach ( $custom_attr as $custom ) {
 			$attribute_key = $custom['attribute'];

--- a/doofinder-for-woocommerce/includes/class-doofinder-constants.php
+++ b/doofinder-for-woocommerce/includes/class-doofinder-constants.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Doofinder_Constants {
 
-	const VERSION            = '2.15.2';
+	const VERSION            = '2.15.3';
 	const PLUGINS_URL_FORMAT = 'https://%splugins.doofinder.com';
 	const API_URL_FORMAT     = 'https://%sadmin.doofinder.com';
 }

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -125,8 +125,9 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+
 = 2.15.3 =
-- Fixed custom attributes overwriting product data.
+- Fixed custom attributes overwriting authoritative product data returned by the WooCommerce REST API.
 
 = 2.15.2 =
 - Fixed the indexing status banner so the spinner stops when an indexation failure is reported.

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.15.2
+Version: 2.15.3
 Requires at least: 5.6
 Tested up to: 6.9
 Requires PHP: 7.0
-Stable tag: 2.15.2
+Stable tag: 2.15.3
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -125,6 +125,8 @@ For in-depth insights into Doofinder and its features, check out our comprehensi
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/doofinder-for-woocommerce)
 
 == Changelog ==
+= 2.15.3 =
+- Fixed custom attributes overwriting product data.
 
 = 2.15.2 =
 - Fixed the indexing status banner so the spinner stops when an indexation failure is reported.

--- a/templates/doofinder-for-woocommerce/readme.txt
+++ b/templates/doofinder-for-woocommerce/readme.txt
@@ -126,6 +126,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= 2.15.3 =
+- Fixed custom attributes overwriting authoritative product data returned by the WooCommerce REST API.
+
 = 2.15.2 =
 - Fixed the indexing status banner so the spinner stops when an indexation failure is reported.
 


### PR DESCRIPTION
Resolves [#446](https://github.com/doofinder/doofinder-woocommerce/issues/446#issue-4539086197)

## Summary
- El merge de `$data` (respuesta de la REST API de WooCommerce) con `get_custom_attributes()` se hacía en el orden equivocado, permitiendo que el fallback sobrescribiera valores ya autoritativos de la REST API (metadatos internos/obsoletos de WooCommerce).
- Se invierte el orden del `array_merge()` para que `$data` gane en colisiones de claves, y los atributos personalizados solo rellenen los campos que la REST API no proporciona de forma plana (p. ej. dimensiones).
