### PR TITLE
Added create search engine button when hash id for specific language is empty

### DIFF
--- a/.env
+++ b/.env
@@ -35,6 +35,6 @@ FS_METHOD=direct
 # over `templates/` to regenerate the committed plugin source files. Bump
 # PLUGIN_VERSION here for releases; override the URL formats in .env.local
 # to point the plugin at your own ngrok stack during dev.
-PLUGIN_VERSION=2.15.3
+PLUGIN_VERSION=2.16.0
 DOOFINDER_PLUGINS_URL_FORMAT=https://%splugins.doofinder.com
 DOOFINDER_API_URL_FORMAT=https://%sadmin.doofinder.com

--- a/doofinder-for-woocommerce/assets/js/admin.js
+++ b/doofinder-for-woocommerce/assets/js/admin.js
@@ -119,13 +119,14 @@ jQuery(function () {
         create_search_engine_spinner.removeClass("is-active");
 
         if (response.success && response.data && response.data.hashid) {
-          $("#doofinder-search-engine-hash").val(response.data.hashid);
+          $("#doofinder-search-engine-hash").val(response.data.hashid).attr("readonly", true);
           $(".create-search-engine-result-wrapper")
             .hide()
             .empty()
             .append("Search Engine created!")
             .fadeIn();
-          create_search_engine_btn.attr("disabled", true);
+          create_search_engine_btn.remove();
+          create_search_engine_spinner.remove();
           return;
         }
 

--- a/doofinder-for-woocommerce/assets/js/admin.js
+++ b/doofinder-for-woocommerce/assets/js/admin.js
@@ -102,6 +102,56 @@ jQuery(function () {
   let reset_credentials_btn = $("#doofinder-reset-credentials");
   reset_credentials_btn.on("click", ResetCredentialsHandler);
 
+  let CreateSearchEngineHandler = function () {
+    create_search_engine_btn.attr("disabled", true);
+    create_search_engine_spinner.addClass("is-active");
+
+    $.ajax({
+      type: "post",
+      dataType: "json",
+      url: ajaxurl,
+      data: {
+        action: "doofinder_create_search_engine",
+        lang: create_search_engine_btn.data("lang") || "",
+        nonce: Doofinder.nonce
+      },
+      success: function (response) {
+        create_search_engine_spinner.removeClass("is-active");
+
+        if (response.success && response.data && response.data.hashid) {
+          $("#doofinder-search-engine-hash").val(response.data.hashid);
+          $(".create-search-engine-result-wrapper")
+            .hide()
+            .empty()
+            .append("Search Engine created!")
+            .fadeIn();
+          create_search_engine_btn.remove();
+          return;
+        }
+
+        $(".create-search-engine-result-wrapper")
+          .hide()
+          .empty()
+          .append("Error creating the Search Engine, please try again later")
+          .fadeIn();
+        create_search_engine_btn.attr("disabled", false);
+      },
+      error: function () {
+        create_search_engine_spinner.removeClass("is-active");
+        $(".create-search-engine-result-wrapper")
+          .hide()
+          .empty()
+          .append("Error creating the Search Engine, please try again later")
+          .fadeIn();
+        create_search_engine_btn.attr("disabled", false);
+      },
+    });
+  };
+
+  let create_search_engine_btn = $("#doofinder-create-search-engine");
+  let create_search_engine_spinner = $("#doofinder-create-search-engine-spinner");
+  create_search_engine_btn.on("click", CreateSearchEngineHandler);
+
   let CustomAttributesHandler = {
     valid: true,
     init: function () {

--- a/doofinder-for-woocommerce/assets/js/admin.js
+++ b/doofinder-for-woocommerce/assets/js/admin.js
@@ -125,7 +125,7 @@ jQuery(function () {
             .empty()
             .append("Search Engine created!")
             .fadeIn();
-          create_search_engine_btn.remove();
+          create_search_engine_btn.attr("disabled", true);
           return;
         }
 

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -116,8 +116,8 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 					Update_On_Save::init();
 					// Initialize reset credentials.
 					Reset_Credentials::init();
-					// Initialize the "Create Search Engine" button handler.
-					Search_Engine_Creator::init();
+					// Initialize Search Engine related admin operations.
+					Search_Engine::init();
 
 					// Init admin functionalities.
 					if ( is_admin() ) {

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: DOOFINDER Search and Discovery for WP & WooCommerce
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
- * Version: 2.15.3
+ * Version: 2.16.0
  * Requires at least: 5.6
  * Requires PHP: 7.0
  * Author: Doofinder
@@ -44,7 +44,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 		 * @var string
 		 */
 
-		public static $version = '2.15.3';
+		public static $version = '2.16.0';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -116,6 +116,8 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 					Update_On_Save::init();
 					// Initialize reset credentials.
 					Reset_Credentials::init();
+					// Initialize the "Create Search Engine" button handler.
+					Search_Engine_Creator::init();
 
 					// Init admin functionalities.
 					if ( is_admin() ) {

--- a/doofinder-for-woocommerce/includes/api/class-store-api.php
+++ b/doofinder-for-woocommerce/includes/api/class-store-api.php
@@ -198,7 +198,7 @@ class Store_Api {
 
 		$response = $this->send_request( 'install/search-engine', $payload, true );
 
-		return is_array( $response ) ? ( $response['hashid'] ?? null ) : null;
+		return ! empty( $response['hashid'] ) ? $response['hashid'] : null;
 	}
 
 	/**

--- a/doofinder-for-woocommerce/includes/api/class-store-api.php
+++ b/doofinder-for-woocommerce/includes/api/class-store-api.php
@@ -168,6 +168,40 @@ class Store_Api {
 	}
 
 	/**
+	 * Creates a single missing Search Engine for a language via the universal
+	 * install endpoint, without resending (and reprocessing) the whole store.
+	 *
+	 * @param array|null $lang Language data, as returned by Multilanguage::get_languages().
+	 *                         Null when there's no multilanguage plugin active, in which
+	 *                         case the site's primary language is used instead.
+	 *
+	 * @return string|null The new Search Engine hashid, or null on failure.
+	 */
+	public function create_search_engine_for_language( $lang = null ) {
+		$locale        = Helpers::format_locale_to_hyphen( $lang['locale'] ?? $this->get_primary_language() );
+		$language_code = Helpers::get_language_from_locale( $locale );
+		$home_url      = $this->language->get_home_url( $language_code );
+
+		$payload = array(
+			'store_id'     => Settings::get_installation_id(),
+			'language'     => $language_code,
+			'locale'       => $locale,
+			'currency'     => is_plugin_active( 'woocommerce/woocommerce.php' ) ? get_woocommerce_currency() : 'EUR',
+			'callback_url' => $this->build_callback_url(
+				$home_url,
+				'/?rest_route=/doofinder/v1/index-status&token=' . $this->api_key
+			),
+		);
+
+		$this->log->log( 'Creating Search Engine for language: ' );
+		$this->log->log( $payload );
+
+		$response = $this->send_request( 'install/search-engine', $payload, true );
+
+		return is_array( $response ) ? ( $response['hashid'] ?? null ) : null;
+	}
+
+	/**
 	 * Send a POST request with the given $body to the given $endpoint.
 	 *
 	 * @param string $endpoint The endpoint url.

--- a/doofinder-for-woocommerce/includes/class-doofinder-constants.php
+++ b/doofinder-for-woocommerce/includes/class-doofinder-constants.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Doofinder_Constants {
 
-	const VERSION            = '2.15.3';
+	const VERSION            = '2.16.0';
 	const PLUGINS_URL_FORMAT = 'https://%splugins.doofinder.com';
 	const API_URL_FORMAT     = 'https://%sadmin.doofinder.com';
 }

--- a/doofinder-for-woocommerce/includes/class-search-engine-creator.php
+++ b/doofinder-for-woocommerce/includes/class-search-engine-creator.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * DooFinder Search_Engine_Creator methods.
+ *
+ * @package Doofinder\WP
+ */
+
+namespace Doofinder\WP;
+
+use Doofinder\WP\Api\Store_Api;
+use Doofinder\WP\Multilanguage\Multilanguage;
+use WP_Http;
+
+/**
+ * Search_Engine_Creator Class.
+ *
+ * Handles the "Create Search Engine" button shown in the settings page next
+ * to the Search Engine hash field, for languages that don't have one yet.
+ */
+class Search_Engine_Creator {
+
+	/**
+	 * Initializes the action hooks.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'wp_ajax_doofinder_create_search_engine', array( __CLASS__, 'handle_ajax_request' ) );
+	}
+
+	/**
+	 * Handles the AJAX request to create a Search Engine for the given language.
+	 *
+	 * @return void
+	 */
+	public static function handle_ajax_request() {
+		if ( ! isset( $_POST['nonce'] ) || ! current_user_can( 'manage_options' ) || ! wp_verify_nonce( sanitize_key( $_POST['nonce'] ), 'doofinder-ajax-nonce' ) ) {
+			status_header( WP_Http::UNAUTHORIZED );
+			die( 'Unauthorized request' );
+		}
+
+		$multilanguage = Multilanguage::instance();
+		$lang_code     = isset( $_POST['lang'] ) ? sanitize_text_field( wp_unslash( $_POST['lang'] ) ) : '';
+		$lang          = null;
+
+		if ( $lang_code ) {
+			$languages = $multilanguage->get_languages();
+			$lang      = is_array( $languages ) ? ( $languages[ $lang_code ] ?? null ) : null;
+
+			if ( ! $lang ) {
+				wp_send_json_error( array( 'message' => 'Invalid language' ) );
+			}
+		}
+
+		$storage_code = self::get_storage_code( $multilanguage, $lang_code );
+		$existing     = Settings::get_search_engine_hash( $storage_code );
+
+		if ( $existing ) {
+			// Already created (e.g. a concurrent request); nothing else to do.
+			wp_send_json_success( array( 'hashid' => $existing ) );
+		}
+
+		$hash = ( new Store_Api() )->create_search_engine_for_language( $lang );
+
+		if ( ! $hash ) {
+			wp_send_json_error( array( 'message' => 'Search Engine creation failed' ) );
+		}
+
+		Settings::set_search_engine_hash( $hash, $storage_code );
+
+		wp_send_json_success( array( 'hashid' => $hash ) );
+	}
+
+	/**
+	 * Normalizes a raw WPML language code into the code used to store the
+	 * Search Engine hash: an empty string for the base/default language,
+	 * the language code itself otherwise. Mirrors the same normalization
+	 * WPML::get_option_name() applies when building the settings option name.
+	 *
+	 * @param object $multilanguage Multilanguage instance.
+	 * @param string $lang_code     Raw WPML language code (empty for no multilanguage plugin).
+	 *
+	 * @return string
+	 */
+	private static function get_storage_code( $multilanguage, $lang_code ) {
+		if ( ! $lang_code ) {
+			return '';
+		}
+
+		return $lang_code === $multilanguage->get_base_language() ? '' : $lang_code;
+	}
+}

--- a/doofinder-for-woocommerce/includes/class-search-engine.php
+++ b/doofinder-for-woocommerce/includes/class-search-engine.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * DooFinder Search_Engine_Creator methods.
+ * DooFinder Search_Engine methods.
  *
  * @package Doofinder\WP
  */
@@ -12,12 +12,13 @@ use Doofinder\WP\Multilanguage\Multilanguage;
 use WP_Http;
 
 /**
- * Search_Engine_Creator Class.
+ * Search_Engine Class.
  *
- * Handles the "Create Search Engine" button shown in the settings page next
- * to the Search Engine hash field, for languages that don't have one yet.
+ * Groups Search Engine related admin operations. Currently only handles the
+ * "Create Search Engine" button shown in the settings page next to the
+ * Search Engine hash field, for languages that don't have one yet.
  */
-class Search_Engine_Creator {
+class Search_Engine {
 
 	/**
 	 * Initializes the action hooks.

--- a/doofinder-for-woocommerce/includes/settings/class-accessors.php
+++ b/doofinder-for-woocommerce/includes/settings/class-accessors.php
@@ -170,6 +170,30 @@ trait Accessors {
 	}
 
 	/**
+	 * Retrieve the Doofinder installation ID (the "store ID" used by dooplugins).
+	 *
+	 * It's not persisted as its own option; it's extracted from the layer script
+	 * already stored in the "js_layer" option, which always contains it, either as
+	 * part of the single-script URL or, for stores not yet migrated to the single
+	 * script, as an inline `installationId` value.
+	 *
+	 * @return string
+	 */
+	public static function get_installation_id() {
+		$script = self::get_js_layer();
+
+		if ( preg_match( '/-config\.doofinder\.com\/2\.x\/(?P<installation_id>[a-zA-Z0-9-]+)\.js/', $script, $matches ) ) {
+			return $matches['installation_id'];
+		}
+
+		if ( preg_match( "/installationId: '(?P<installation_id>[a-z0-9-]+)'/", $script, $matches ) ) {
+			return $matches['installation_id'];
+		}
+
+		return '';
+	}
+
+	/**
 	 * Retrieve the chosen update on save option.
 	 *
 	 * Just an alias for "get_option" to avoid repeating the string

--- a/doofinder-for-woocommerce/includes/settings/class-accessors.php
+++ b/doofinder-for-woocommerce/includes/settings/class-accessors.php
@@ -170,7 +170,7 @@ trait Accessors {
 	}
 
 	/**
-	 * Retrieve the Doofinder installation ID (the "store ID" used by dooplugins).
+	 * Retrieve the Doofinder installation ID (the "store ID" used by Dooplugins).
 	 *
 	 * It's not persisted as its own option; it's extracted from the layer script
 	 * already stored in the "js_layer" option, which always contains it, either as

--- a/doofinder-for-woocommerce/includes/settings/class-renderers.php
+++ b/doofinder-for-woocommerce/includes/settings/class-renderers.php
@@ -333,11 +333,24 @@ trait Renderers {
 		?>
 												</span></span>
 
-		<input type="text" name="<?php echo esc_attr( $option_name ); ?>" class="widefat" 
-											<?php
-											if ( $saved_value ) :
-												?>
-			value="<?php echo esc_attr( htmlspecialchars( $saved_value ) ); ?>" <?php endif; ?>>
+		<div style="display: flex; align-items: center; gap: 8px;">
+			<input type="text" name="<?php echo esc_attr( $option_name ); ?>" id="doofinder-search-engine-hash" class="widefat" style="flex: 1;"
+												<?php
+												if ( $saved_value ) :
+													?>
+				value="<?php echo esc_attr( htmlspecialchars( $saved_value ) ); ?>" <?php endif; ?>>
+
+			<?php if ( ! $saved_value ) : ?>
+				<button type="button" id="doofinder-create-search-engine" class="button-secondary" style="white-space: nowrap;" data-lang="<?php echo esc_attr( (string) $this->language->get_active_language() ); ?>">
+					<?php esc_html_e( 'Create Search Engine', 'wordpress-doofinder' ); ?>
+				</button>
+				<span class="spinner" id="doofinder-create-search-engine-spinner" style="float: none; margin: 0;"></span>
+			<?php endif; ?>
+		</div>
+
+		<?php if ( ! $saved_value ) : ?>
+			<span class="create-search-engine-result-wrapper"></span>
+		<?php endif; ?>
 
 		<?php
 	}

--- a/doofinder-for-woocommerce/includes/settings/class-renderers.php
+++ b/doofinder-for-woocommerce/includes/settings/class-renderers.php
@@ -334,16 +334,18 @@ trait Renderers {
 												</span></span>
 
 		<div style="display: flex; align-items: center; gap: 8px;">
-			<input type="text" name="<?php echo esc_attr( $option_name ); ?>" id="doofinder-search-engine-hash" class="widefat" style="flex: 1;"
+			<input type="text" name="<?php echo esc_attr( $option_name ); ?>" id="doofinder-search-engine-hash" class="widefat" style="flex: 1;" <?php echo $saved_value ? 'readonly="readonly"' : ''; ?>
 												<?php
 												if ( $saved_value ) :
 													?>
 				value="<?php echo esc_attr( htmlspecialchars( $saved_value ) ); ?>" <?php endif; ?>>
 
-			<button type="button" id="doofinder-create-search-engine" class="button-secondary" style="white-space: nowrap;" data-lang="<?php echo esc_attr( (string) $this->language->get_active_language() ); ?>" <?php disabled( (bool) $saved_value ); ?>>
-				<?php esc_html_e( 'Create Search Engine', 'wordpress-doofinder' ); ?>
-			</button>
-			<span class="spinner" id="doofinder-create-search-engine-spinner" style="float: none; margin: 0;"></span>
+			<?php if ( ! $saved_value ) : ?>
+				<button type="button" id="doofinder-create-search-engine" class="button-secondary" style="white-space: nowrap;" data-lang="<?php echo esc_attr( (string) $this->language->get_active_language() ); ?>">
+					<?php esc_html_e( 'Create Search Engine', 'wordpress-doofinder' ); ?>
+				</button>
+				<span class="spinner" id="doofinder-create-search-engine-spinner" style="float: none; margin: 0;"></span>
+			<?php endif; ?>
 		</div>
 
 		<span class="create-search-engine-result-wrapper"></span>

--- a/doofinder-for-woocommerce/includes/settings/class-renderers.php
+++ b/doofinder-for-woocommerce/includes/settings/class-renderers.php
@@ -340,17 +340,13 @@ trait Renderers {
 													?>
 				value="<?php echo esc_attr( htmlspecialchars( $saved_value ) ); ?>" <?php endif; ?>>
 
-			<?php if ( ! $saved_value ) : ?>
-				<button type="button" id="doofinder-create-search-engine" class="button-secondary" style="white-space: nowrap;" data-lang="<?php echo esc_attr( (string) $this->language->get_active_language() ); ?>">
-					<?php esc_html_e( 'Create Search Engine', 'wordpress-doofinder' ); ?>
-				</button>
-				<span class="spinner" id="doofinder-create-search-engine-spinner" style="float: none; margin: 0;"></span>
-			<?php endif; ?>
+			<button type="button" id="doofinder-create-search-engine" class="button-secondary" style="white-space: nowrap;" data-lang="<?php echo esc_attr( (string) $this->language->get_active_language() ); ?>" <?php disabled( (bool) $saved_value ); ?>>
+				<?php esc_html_e( 'Create Search Engine', 'wordpress-doofinder' ); ?>
+			</button>
+			<span class="spinner" id="doofinder-create-search-engine-spinner" style="float: none; margin: 0;"></span>
 		</div>
 
-		<?php if ( ! $saved_value ) : ?>
-			<span class="create-search-engine-result-wrapper"></span>
-		<?php endif; ?>
+		<span class="create-search-engine-result-wrapper"></span>
 
 		<?php
 	}

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -126,6 +126,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= 2.16.0 =
+- Added a button to create the Search Engine for a new language without reinstalling the plugin.
+
 = 2.15.3 =
 - Fixed custom attributes overwriting authoritative product data returned by the WooCommerce REST API.
 

--- a/doofinder-for-woocommerce/readme.txt
+++ b/doofinder-for-woocommerce/readme.txt
@@ -1,11 +1,11 @@
 === DOOFINDER Search and Discovery for WP & WooCommerce ===
 Contributors: Doofinder
 Tags: search, autocomplete
-Version: 2.15.3
+Version: 2.16.0
 Requires at least: 5.6
 Tested up to: 6.9
 Requires PHP: 7.0
-Stable tag: 2.15.3
+Stable tag: 2.16.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 

--- a/templates/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/templates/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -116,8 +116,8 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 					Update_On_Save::init();
 					// Initialize reset credentials.
 					Reset_Credentials::init();
-					// Initialize the "Create Search Engine" button handler.
-					Search_Engine_Creator::init();
+					// Initialize Search Engine related admin operations.
+					Search_Engine::init();
 
 					// Init admin functionalities.
 					if ( is_admin() ) {

--- a/templates/doofinder-for-woocommerce/doofinder-for-woocommerce.php
+++ b/templates/doofinder-for-woocommerce/doofinder-for-woocommerce.php
@@ -116,6 +116,8 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ) :
 					Update_On_Save::init();
 					// Initialize reset credentials.
 					Reset_Credentials::init();
+					// Initialize the "Create Search Engine" button handler.
+					Search_Engine_Creator::init();
 
 					// Init admin functionalities.
 					if ( is_admin() ) {

--- a/templates/doofinder-for-woocommerce/readme.txt
+++ b/templates/doofinder-for-woocommerce/readme.txt
@@ -126,6 +126,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= 2.16.0 =
+- Added a button to create the Search Engine for a new language without reinstalling the plugin.
+
 = 2.15.3 =
 - Fixed custom attributes overwriting authoritative product data returned by the WooCommerce REST API.
 


### PR DESCRIPTION
Resolves [https://github.com/doofinder/dooplugins/issues/2471](https://github.com/doofinder/dooplugins/issues/2471) for woocommerce 

Adds a manual way to create the missing Search Engine for a lan…guage, instead of requiring a whole reinstall

- Show a "Create Search Engine" button next to the hash field on the settings page whenever the current language has no hash saved.
- New Search_Engine_Creator class handles the wp_ajax_doofinder_create_search_engine AJAX action: resolves the language, calls dooplugins, and persists the returned hash.
- New Store_Api::create_search_engine_for_language() builds the payload and calls POST /install/search-engine directly, without resending (and reprocessing) the whole store.
- New Settings::get_installation_id(), extracting the dooplugins store ID from the already-stored layer script instead of requiring new persistence.
- Update the hash field in place and show a loading spinner while the request is in flight.
<img width="800" height="252" alt="ezgif-2d24fbe77fae524e" src="https://github.com/user-attachments/assets/ca2e9cca-c65d-4459-befa-bde9b091d8d7" />
