### PR TITLE
Build(deps): Bump grunt to 1.6.3 and drop js-yaml override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -962,24 +962,25 @@
       "dev": true
     },
     "node_modules/grunt": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
-      "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.3.tgz",
+      "integrity": "sha512-ng0CbpyNp/ox5e5CBY9TkZgVdAL4wK+nBHO6rNE8cXGa5kM++Lxlp0MpFBVZbpgOR2oCp/91V+T3CZVSWWLqMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "dateformat": "~4.6.2",
         "eventemitter2": "~0.4.13",
         "exit": "~0.1.2",
         "findup-sync": "~5.0.0",
         "glob": "~7.1.6",
-        "grunt-cli": "~1.4.3",
+        "grunt-cli": "^1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
         "iconv-lite": "~0.6.3",
-        "js-yaml": "~3.14.0",
-        "minimatch": "~3.0.4",
-        "nopt": "~3.0.6"
+        "js-yaml": "^3.15.0",
+        "minimatch": "^3.1.5",
+        "nopt": "^5.0.0"
       },
       "bin": {
         "grunt": "bin/grunt"
@@ -1745,16 +1746,6 @@
         "semver": "^5.4.1"
       }
     },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/noop-logger": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
@@ -1763,15 +1754,19 @@
       "optional": true
     },
     "node_modules/nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "abbrev": "1"
       },
       "bin": {
         "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/normalize-path": {
@@ -3376,9 +3371,9 @@
       "dev": true
     },
     "grunt": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
-      "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.3.tgz",
+      "integrity": "sha512-ng0CbpyNp/ox5e5CBY9TkZgVdAL4wK+nBHO6rNE8cXGa5kM++Lxlp0MpFBVZbpgOR2oCp/91V+T3CZVSWWLqMA==",
       "dev": true,
       "requires": {
         "dateformat": "~4.6.2",
@@ -3386,14 +3381,14 @@
         "exit": "~0.1.2",
         "findup-sync": "~5.0.0",
         "glob": "~7.1.6",
-        "grunt-cli": "~1.4.3",
+        "grunt-cli": "^1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
         "iconv-lite": "~0.6.3",
-        "js-yaml": "~3.15.0",
+        "js-yaml": "^3.15.0",
         "minimatch": "~3.1.3",
-        "nopt": "~3.0.6"
+        "nopt": "^5.0.0"
       }
     },
     "grunt-cli": {
@@ -3957,15 +3952,6 @@
       "optional": true,
       "requires": {
         "semver": ">=5.7.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "noop-logger": {
@@ -3976,9 +3962,9 @@
       "optional": true
     },
     "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
       "dev": true,
       "requires": {
         "abbrev": "1"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "tough-cookie": ">=4.1.3",
     "node-gyp": ">=10.0.0",
     "minimatch": "~3.1.3",
-    "lodash": ">=4.18.0",
-    "js-yaml": "~3.15.0"
+    "lodash": ">=4.18.0"
   }
 }


### PR DESCRIPTION
grunt 1.6.1 pinned its own js-yaml dependency to ~3.14.0, which is why the js-yaml override was needed to reach the patched 3.15.1. grunt 1.6.3 already requires js-yaml ^3.15.0 natively, so js-yaml now resolves to 3.15.1 on its own without forcing anything via overrides.

This should also unblock Dependabot for this dependency: its resolver struggled with the override forcing a version across multiple requirers pinning different ranges for the same package.